### PR TITLE
ホーム画面で表示する定義一覧の取得処理を実装

### DIFF
--- a/lib/feature/definition/application/definition_id_list_state.dart
+++ b/lib/feature/definition/application/definition_id_list_state.dart
@@ -68,7 +68,7 @@ class DefinitionIdListStateNotifier extends _$DefinitionIdListStateNotifier
 
     return ref
         .read(definitionRepositoryProvider)
-        .fetchHomeFollowingDefinitionIdList(
+        .fetchHomeFollowingDefinitionIdListState(
           currentUserId,
           targetUserIdList,
           lastDoc,

--- a/lib/feature/definition/application/definition_id_list_state.dart
+++ b/lib/feature/definition/application/definition_id_list_state.dart
@@ -21,7 +21,7 @@ class DefinitionIdListStateNotifier extends _$DefinitionIdListStateNotifier
     // ミュートユーザーが更新されるたびに、本Notifierも更新されるよう監視
     ref.watch(mutedUserIdListProvider);
 
-    return await _fetchMoreBasedOnType(isFirstFetch: true);
+    return await _fetchBasedOnType(isFirstFetch: true);
   }
 
   /// 「ホーム画面: おすすめタブ」で表示するDefinitionIDのListを取得する
@@ -30,13 +30,15 @@ class DefinitionIdListStateNotifier extends _$DefinitionIdListStateNotifier
   Future<DefinitionIdListState> _fetchForHomeRecommend({
     required bool isFirstFetch,
   }) async {
+    final currentUserId = ref.read(userIdProvider)!;
     final mutedUserIdList = await ref.read(mutedUserIdListProvider.future);
     final lastDoc =
         isFirstFetch ? null : state.value?.lastReadQueryDocumentSnapshot;
 
     return ref
         .watch(definitionRepositoryProvider)
-        .fetchHomeRecommendDefinitionIdList(
+        .fetchHomeRecommendDefinitionIdListState(
+          currentUserId,
           mutedUserIdList,
           lastDoc,
         );
@@ -87,7 +89,9 @@ class DefinitionIdListStateNotifier extends _$DefinitionIdListStateNotifier
     final lastDoc =
         isFirstFetch ? null : state.value?.lastReadQueryDocumentSnapshot;
 
-    return ref.watch(definitionRepositoryProvider).fetchWordTopDefinitionIdList(
+    return ref
+        .watch(definitionRepositoryProvider)
+        .fetchWordTopDefinitionIdListState(
           orderByType,
           currentUserId,
           mutedUserIdList,
@@ -99,7 +103,7 @@ class DefinitionIdListStateNotifier extends _$DefinitionIdListStateNotifier
   Future<void> fetchMore() async {
     await fetchMoreHelper(
       ref: ref,
-      fetchFunction: () => _fetchMoreBasedOnType(isFirstFetch: false),
+      fetchFunction: () => _fetchBasedOnType(isFirstFetch: false),
       mergeFunction: (currentData, newData) => DefinitionIdListState(
         definitionIdList:
             currentData.definitionIdList + newData.definitionIdList,
@@ -109,7 +113,7 @@ class DefinitionIdListStateNotifier extends _$DefinitionIdListStateNotifier
     );
   }
 
-  Future<DefinitionIdListState> _fetchMoreBasedOnType({
+  Future<DefinitionIdListState> _fetchBasedOnType({
     required bool isFirstFetch,
   }) async {
     switch (definitionFeedType) {

--- a/lib/feature/definition/application/definition_id_list_state.dart
+++ b/lib/feature/definition/application/definition_id_list_state.dart
@@ -50,17 +50,14 @@ class DefinitionIdListStateNotifier extends _$DefinitionIdListStateNotifier
   Future<DefinitionIdListState> _fetchForHomeFollowing({
     required bool isFirstFetch,
   }) async {
-    final targetUserIdList = <String>[];
-    final userId = ref.read(userIdProvider)!;
+    final currentUserId = ref.read(userIdProvider)!;
 
     // フォローしているユーザーのIDリストを取得
     final followingIdList =
-        await ref.read(followingIdListProvider(userId).future);
+        await ref.read(followingIdListProvider(currentUserId).future);
 
     // フォローしているユーザーと自分のIDを追加
-    targetUserIdList
-      ..addAll(followingIdList)
-      ..add(userId);
+    final targetUserIdList = <String>[...followingIdList, currentUserId];
 
     // ミュートしているユーザーのIDを除外
     final mutedUserIdList = await ref.read(mutedUserIdListProvider.future);
@@ -72,6 +69,7 @@ class DefinitionIdListStateNotifier extends _$DefinitionIdListStateNotifier
     return ref
         .read(definitionRepositoryProvider)
         .fetchHomeFollowingDefinitionIdList(
+          currentUserId,
           targetUserIdList,
           lastDoc,
         );

--- a/lib/feature/definition/application/definition_id_list_state.g.dart
+++ b/lib/feature/definition/application/definition_id_list_state.g.dart
@@ -7,7 +7,7 @@ part of 'definition_id_list_state.dart';
 // **************************************************************************
 
 String _$definitionIdListStateNotifierHash() =>
-    r'1c3848df63e61995411db88ceaf3108eb03cfa07';
+    r'ad746c8cbe7521c5d129feb8a5f9530852d2aa45';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/feature/definition/application/definition_id_list_state.g.dart
+++ b/lib/feature/definition/application/definition_id_list_state.g.dart
@@ -7,7 +7,7 @@ part of 'definition_id_list_state.dart';
 // **************************************************************************
 
 String _$definitionIdListStateNotifierHash() =>
-    r'ad746c8cbe7521c5d129feb8a5f9530852d2aa45';
+    r'1a4936f2d0b182284e2a199fede6155fb125975e';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/feature/definition/repository/definition_repository.dart
+++ b/lib/feature/definition/repository/definition_repository.dart
@@ -3,7 +3,7 @@ import 'dart:math';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../../../core/common_provider/firebase_providers.dart';
+import '../../../core/common_provider/firebase_providers.dart'; 
 import '../../../util/constant/config_constant.dart';
 import '../../../util/extension/firestore_extension.dart';
 import '../domain/definition_for_write.dart';
@@ -79,7 +79,7 @@ class DefinitionRepository {
   /// [lastDocument]がnullの場合、最初のdocumentから取得する。
   /// 無限スクロールなどで、2回目以降の取得の場合、
   /// [lastDocument]に前回取得した最後のdocumentを指定すること。
-  Future<DefinitionIdListState> fetchHomeFollowingDefinitionIdList(
+  Future<DefinitionIdListState> fetchHomeFollowingDefinitionIdListState(
     String currentUserId,
     List<String> targetUserIdList,
     QueryDocumentSnapshot? lastDocument,

--- a/lib/feature/user_profile/application/user_follow_service.dart
+++ b/lib/feature/user_profile/application/user_follow_service.dart
@@ -72,7 +72,7 @@ class UserFollowService extends _$UserFollowService {
 
   /// ログイン中のユーザーと[targetUserId]のuserProfileProvider, isFollowingProviderを再生成する
   /// 
-  /// フォロー/フォロー解除時に使用する
+  /// フォロー/フォロー解除時に使用することで、フォロー/フォロワー数が更新される
   void _invalidateRelatedUserProvider(String targetUserId) {
     final currentUserId = ref.read(userIdProvider)!;
 

--- a/lib/feature/user_profile/application/user_follow_service.dart
+++ b/lib/feature/user_profile/application/user_follow_service.dart
@@ -64,6 +64,7 @@ class UserFollowService extends _$UserFollowService {
       return;
     }
 
+    // UI上でのフォロー/フォロワー数を更新するため、
     // フォローした/されたユーザーのProviderを再生成
     _invalidateRelatedUserProvider(targetUserId);
 
@@ -71,8 +72,6 @@ class UserFollowService extends _$UserFollowService {
   }
 
   /// ログイン中のユーザーと[targetUserId]のuserProfileProvider, isFollowingProviderを再生成する
-  /// 
-  /// フォロー/フォロー解除時に使用することで、フォロー/フォロワー数が更新される
   void _invalidateRelatedUserProvider(String targetUserId) {
     final currentUserId = ref.read(userIdProvider)!;
 

--- a/test/feature/definition/application/definition_id_list_state_test.dart
+++ b/test/feature/definition/application/definition_id_list_state_test.dart
@@ -149,7 +149,7 @@ void main() {
       ).thenAnswer((_) async => mockUserProfileDoc);
       final mockDefinitionIdList = [mockDefinitionDoc.id];
       when(
-        mockDefinitionRepository.fetchHomeFollowingDefinitionIdList(
+        mockDefinitionRepository.fetchHomeFollowingDefinitionIdListState(
           any,
           any,
           any,
@@ -201,7 +201,7 @@ void main() {
       // 想定通りにrepositoryの関数が呼ばれているか検証
       // TODO(me): mutedUserIdListを除外したuserIdListを引数に渡していることを検証
       verify(
-        mockDefinitionRepository.fetchHomeFollowingDefinitionIdList(
+        mockDefinitionRepository.fetchHomeFollowingDefinitionIdListState(
           any,
           any,
           null,
@@ -328,7 +328,7 @@ void main() {
         hasMore: true,
       );
       when(
-        mockDefinitionRepository.fetchHomeFollowingDefinitionIdList(
+        mockDefinitionRepository.fetchHomeFollowingDefinitionIdListState(
           any,
           any,
           any,
@@ -338,7 +338,7 @@ void main() {
       );
       final mockDefinitionIdList = [mockDefinitionDoc.id];
       when(
-        mockDefinitionRepository.fetchHomeFollowingDefinitionIdList(
+        mockDefinitionRepository.fetchHomeFollowingDefinitionIdListState(
           any,
           any,
           mockDefinitionIdListState.lastReadQueryDocumentSnapshot,
@@ -419,7 +419,7 @@ void main() {
 
       // 想定通りにrepositoryの関数が呼ばれているか検証
       verify(
-        mockDefinitionRepository.fetchHomeFollowingDefinitionIdList(
+        mockDefinitionRepository.fetchHomeFollowingDefinitionIdListState(
           any,
           any,
           mockDefinitionIdListState.lastReadQueryDocumentSnapshot,

--- a/test/feature/definition/application/definition_id_list_state_test.dart
+++ b/test/feature/definition/application/definition_id_list_state_test.dart
@@ -149,7 +149,11 @@ void main() {
       ).thenAnswer((_) async => mockUserProfileDoc);
       final mockDefinitionIdList = [mockDefinitionDoc.id];
       when(
-        mockDefinitionRepository.fetchHomeFollowingDefinitionIdList(any, any),
+        mockDefinitionRepository.fetchHomeFollowingDefinitionIdList(
+          any,
+          any,
+          any,
+        ),
       ).thenAnswer(
         (_) async => DefinitionIdListState(
           definitionIdList: mockDefinitionIdList,
@@ -197,7 +201,11 @@ void main() {
       // 想定通りにrepositoryの関数が呼ばれているか検証
       // TODO(me): mutedUserIdListを除外したuserIdListを引数に渡していることを検証
       verify(
-        mockDefinitionRepository.fetchHomeFollowingDefinitionIdList(any, null),
+        mockDefinitionRepository.fetchHomeFollowingDefinitionIdList(
+          any,
+          any,
+          null,
+        ),
       ).called(1);
     });
   });
@@ -320,13 +328,18 @@ void main() {
         hasMore: true,
       );
       when(
-        mockDefinitionRepository.fetchHomeFollowingDefinitionIdList(any, any),
+        mockDefinitionRepository.fetchHomeFollowingDefinitionIdList(
+          any,
+          any,
+          any,
+        ),
       ).thenAnswer(
         (_) async => mockDefinitionIdListState,
       );
       final mockDefinitionIdList = [mockDefinitionDoc.id];
       when(
         mockDefinitionRepository.fetchHomeFollowingDefinitionIdList(
+          any,
           any,
           mockDefinitionIdListState.lastReadQueryDocumentSnapshot,
         ),
@@ -407,6 +420,7 @@ void main() {
       // 想定通りにrepositoryの関数が呼ばれているか検証
       verify(
         mockDefinitionRepository.fetchHomeFollowingDefinitionIdList(
+          any,
           any,
           mockDefinitionIdListState.lastReadQueryDocumentSnapshot,
         ),

--- a/test/feature/definition/application/definition_id_list_state_test.dart
+++ b/test/feature/definition/application/definition_id_list_state_test.dart
@@ -83,7 +83,11 @@ void main() {
       // Mockの設定
       final mockDefinitionIdList = [mockDefinitionDoc.id];
       when(
-        mockDefinitionRepository.fetchHomeRecommendDefinitionIdList(any, any),
+        mockDefinitionRepository.fetchHomeRecommendDefinitionIdListState(
+          any,
+          any,
+          any,
+        ),
       ).thenAnswer(
         (_) async => DefinitionIdListState(
           definitionIdList: mockDefinitionIdList,
@@ -130,7 +134,8 @@ void main() {
 
       // 想定通りにrepositoryの関数が呼ばれているか検証
       verify(
-        mockDefinitionRepository.fetchHomeRecommendDefinitionIdList(
+        mockDefinitionRepository.fetchHomeRecommendDefinitionIdListState(
+          userId,
           mockUserConfigDoc.mutedUserIdList,
           null,
         ),
@@ -207,7 +212,8 @@ void main() {
         hasMore: true,
       );
       when(
-        mockDefinitionRepository.fetchHomeRecommendDefinitionIdList(
+        mockDefinitionRepository.fetchHomeRecommendDefinitionIdListState(
+          any,
           any,
           null,
         ),
@@ -216,7 +222,8 @@ void main() {
       );
       final mockDefinitionIdList = [mockDefinitionDoc.id];
       when(
-        mockDefinitionRepository.fetchHomeRecommendDefinitionIdList(
+        mockDefinitionRepository.fetchHomeRecommendDefinitionIdListState(
+          any,
           any,
           mockDefinitionIdListState.lastReadQueryDocumentSnapshot,
         ),
@@ -296,7 +303,8 @@ void main() {
 
       // 想定通りにrepositoryの関数が呼ばれているか検証
       verify(
-        mockDefinitionRepository.fetchHomeRecommendDefinitionIdList(
+        mockDefinitionRepository.fetchHomeRecommendDefinitionIdListState(
+          userId,
           mockUserConfigDoc.mutedUserIdList,
           mockDefinitionIdListState.lastReadQueryDocumentSnapshot,
         ),
@@ -414,7 +422,11 @@ void main() {
         hasMore: false,
       );
       when(
-        mockDefinitionRepository.fetchHomeRecommendDefinitionIdList(any, any),
+        mockDefinitionRepository.fetchHomeRecommendDefinitionIdListState(
+          any,
+          any,
+          any,
+        ),
       ).thenAnswer(
         (_) async => mockDefinitionIdListState,
       );
@@ -455,7 +467,8 @@ void main() {
 
       // 1回しかrepositoryの関数が呼ばれていないことを検証
       verify(
-        mockDefinitionRepository.fetchHomeRecommendDefinitionIdList(
+        mockDefinitionRepository.fetchHomeRecommendDefinitionIdListState(
+          any,
           any,
           any,
         ),
@@ -473,14 +486,19 @@ void main() {
         hasMore: true,
       );
       when(
-        mockDefinitionRepository.fetchHomeRecommendDefinitionIdList(any, any),
+        mockDefinitionRepository.fetchHomeRecommendDefinitionIdListState(
+          any,
+          any,
+          any,
+        ),
       ).thenAnswer(
         (_) async => mockDefinitionIdListState,
       );
       final testException =
           Exception('fetchHomeRecommendDefinitionIdList()で例外発生！！！');
       when(
-        mockDefinitionRepository.fetchHomeRecommendDefinitionIdList(
+        mockDefinitionRepository.fetchHomeRecommendDefinitionIdListState(
+          any,
           any,
           mockDefinitionIdListState.lastReadQueryDocumentSnapshot,
         ),

--- a/test/feature/definition/application/definition_id_list_state_test.mocks.dart
+++ b/test/feature/definition/application/definition_id_list_state_test.mocks.dart
@@ -209,45 +209,47 @@ class MockDefinitionRepository extends _i1.Mock
           ) as _i12.Future<_i3.DefinitionIdListState>);
 
   @override
-  _i12.Future<_i3.DefinitionIdListState> fetchHomeFollowingDefinitionIdList(
+  _i12.Future<_i3.DefinitionIdListState>
+      fetchHomeFollowingDefinitionIdListState(
     String? currentUserId,
     List<String>? targetUserIdList,
     _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #fetchHomeFollowingDefinitionIdList,
-          [
-            currentUserId,
-            targetUserIdList,
-            lastDocument,
-          ],
-        ),
-        returnValue: _i12.Future<_i3.DefinitionIdListState>.value(
-            _FakeDefinitionIdListState_1(
-          this,
-          Invocation.method(
-            #fetchHomeFollowingDefinitionIdList,
-            [
-              currentUserId,
-              targetUserIdList,
-              lastDocument,
-            ],
-          ),
-        )),
-        returnValueForMissingStub: _i12.Future<_i3.DefinitionIdListState>.value(
-            _FakeDefinitionIdListState_1(
-          this,
-          Invocation.method(
-            #fetchHomeFollowingDefinitionIdList,
-            [
-              currentUserId,
-              targetUserIdList,
-              lastDocument,
-            ],
-          ),
-        )),
-      ) as _i12.Future<_i3.DefinitionIdListState>);
+          (super.noSuchMethod(
+            Invocation.method(
+              #fetchHomeFollowingDefinitionIdList,
+              [
+                currentUserId,
+                targetUserIdList,
+                lastDocument,
+              ],
+            ),
+            returnValue: _i12.Future<_i3.DefinitionIdListState>.value(
+                _FakeDefinitionIdListState_1(
+              this,
+              Invocation.method(
+                #fetchHomeFollowingDefinitionIdList,
+                [
+                  currentUserId,
+                  targetUserIdList,
+                  lastDocument,
+                ],
+              ),
+            )),
+            returnValueForMissingStub:
+                _i12.Future<_i3.DefinitionIdListState>.value(
+                    _FakeDefinitionIdListState_1(
+              this,
+              Invocation.method(
+                #fetchHomeFollowingDefinitionIdList,
+                [
+                  currentUserId,
+                  targetUserIdList,
+                  lastDocument,
+                ],
+              ),
+            )),
+          ) as _i12.Future<_i3.DefinitionIdListState>);
 
   @override
   _i12.Future<_i3.DefinitionIdListState> fetchWordTopDefinitionIdListState(

--- a/test/feature/definition/application/definition_id_list_state_test.mocks.dart
+++ b/test/feature/definition/application/definition_id_list_state_test.mocks.dart
@@ -210,6 +210,7 @@ class MockDefinitionRepository extends _i1.Mock
 
   @override
   _i12.Future<_i3.DefinitionIdListState> fetchHomeFollowingDefinitionIdList(
+    String? currentUserId,
     List<String>? targetUserIdList,
     _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
@@ -217,6 +218,7 @@ class MockDefinitionRepository extends _i1.Mock
         Invocation.method(
           #fetchHomeFollowingDefinitionIdList,
           [
+            currentUserId,
             targetUserIdList,
             lastDocument,
           ],
@@ -227,6 +229,7 @@ class MockDefinitionRepository extends _i1.Mock
           Invocation.method(
             #fetchHomeFollowingDefinitionIdList,
             [
+              currentUserId,
               targetUserIdList,
               lastDocument,
             ],
@@ -238,6 +241,7 @@ class MockDefinitionRepository extends _i1.Mock
           Invocation.method(
             #fetchHomeFollowingDefinitionIdList,
             [
+              currentUserId,
               targetUserIdList,
               lastDocument,
             ],

--- a/test/feature/definition/application/definition_id_list_state_test.mocks.dart
+++ b/test/feature/definition/application/definition_id_list_state_test.mocks.dart
@@ -166,41 +166,47 @@ class MockDefinitionRepository extends _i1.Mock
       ) as _i2.FirebaseFirestore);
 
   @override
-  _i12.Future<_i3.DefinitionIdListState> fetchHomeRecommendDefinitionIdList(
+  _i12.Future<_i3.DefinitionIdListState>
+      fetchHomeRecommendDefinitionIdListState(
+    String? currentUserId,
     List<String>? mutedUserIdList,
     _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #fetchHomeRecommendDefinitionIdList,
-          [
-            mutedUserIdList,
-            lastDocument,
-          ],
-        ),
-        returnValue: _i12.Future<_i3.DefinitionIdListState>.value(
-            _FakeDefinitionIdListState_1(
-          this,
-          Invocation.method(
-            #fetchHomeRecommendDefinitionIdList,
-            [
-              mutedUserIdList,
-              lastDocument,
-            ],
-          ),
-        )),
-        returnValueForMissingStub: _i12.Future<_i3.DefinitionIdListState>.value(
-            _FakeDefinitionIdListState_1(
-          this,
-          Invocation.method(
-            #fetchHomeRecommendDefinitionIdList,
-            [
-              mutedUserIdList,
-              lastDocument,
-            ],
-          ),
-        )),
-      ) as _i12.Future<_i3.DefinitionIdListState>);
+          (super.noSuchMethod(
+            Invocation.method(
+              #fetchHomeRecommendDefinitionIdListState,
+              [
+                currentUserId,
+                mutedUserIdList,
+                lastDocument,
+              ],
+            ),
+            returnValue: _i12.Future<_i3.DefinitionIdListState>.value(
+                _FakeDefinitionIdListState_1(
+              this,
+              Invocation.method(
+                #fetchHomeRecommendDefinitionIdListState,
+                [
+                  currentUserId,
+                  mutedUserIdList,
+                  lastDocument,
+                ],
+              ),
+            )),
+            returnValueForMissingStub:
+                _i12.Future<_i3.DefinitionIdListState>.value(
+                    _FakeDefinitionIdListState_1(
+              this,
+              Invocation.method(
+                #fetchHomeRecommendDefinitionIdListState,
+                [
+                  currentUserId,
+                  mutedUserIdList,
+                  lastDocument,
+                ],
+              ),
+            )),
+          ) as _i12.Future<_i3.DefinitionIdListState>);
 
   @override
   _i12.Future<_i3.DefinitionIdListState> fetchHomeFollowingDefinitionIdList(
@@ -240,7 +246,7 @@ class MockDefinitionRepository extends _i1.Mock
       ) as _i12.Future<_i3.DefinitionIdListState>);
 
   @override
-  _i12.Future<_i3.DefinitionIdListState> fetchWordTopDefinitionIdList(
+  _i12.Future<_i3.DefinitionIdListState> fetchWordTopDefinitionIdListState(
     _i13.WordTopOrderByType? orderByType,
     String? currentUserId,
     List<String>? mutedUserIdList,
@@ -249,7 +255,7 @@ class MockDefinitionRepository extends _i1.Mock
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchWordTopDefinitionIdList,
+          #fetchWordTopDefinitionIdListState,
           [
             orderByType,
             currentUserId,
@@ -262,7 +268,7 @@ class MockDefinitionRepository extends _i1.Mock
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
-            #fetchWordTopDefinitionIdList,
+            #fetchWordTopDefinitionIdListState,
             [
               orderByType,
               currentUserId,
@@ -276,7 +282,7 @@ class MockDefinitionRepository extends _i1.Mock
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
-            #fetchWordTopDefinitionIdList,
+            #fetchWordTopDefinitionIdListState,
             [
               orderByType,
               currentUserId,

--- a/test/feature/definition/application/definition_service_test.mocks.dart
+++ b/test/feature/definition/application/definition_service_test.mocks.dart
@@ -125,7 +125,7 @@ class MockDefinitionRepository extends _i1.Mock
       ) as _i6.Future<_i3.DefinitionIdListState>);
 
   @override
-  _i6.Future<_i3.DefinitionIdListState> fetchHomeFollowingDefinitionIdList(
+  _i6.Future<_i3.DefinitionIdListState> fetchHomeFollowingDefinitionIdListState(
     String? currentUserId,
     List<String>? targetUserIdList,
     _i2.QueryDocumentSnapshot<Object?>? lastDocument,

--- a/test/feature/definition/application/definition_service_test.mocks.dart
+++ b/test/feature/definition/application/definition_service_test.mocks.dart
@@ -126,6 +126,7 @@ class MockDefinitionRepository extends _i1.Mock
 
   @override
   _i6.Future<_i3.DefinitionIdListState> fetchHomeFollowingDefinitionIdList(
+    String? currentUserId,
     List<String>? targetUserIdList,
     _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
@@ -133,6 +134,7 @@ class MockDefinitionRepository extends _i1.Mock
         Invocation.method(
           #fetchHomeFollowingDefinitionIdList,
           [
+            currentUserId,
             targetUserIdList,
             lastDocument,
           ],
@@ -143,6 +145,7 @@ class MockDefinitionRepository extends _i1.Mock
           Invocation.method(
             #fetchHomeFollowingDefinitionIdList,
             [
+              currentUserId,
               targetUserIdList,
               lastDocument,
             ],
@@ -154,6 +157,7 @@ class MockDefinitionRepository extends _i1.Mock
           Invocation.method(
             #fetchHomeFollowingDefinitionIdList,
             [
+              currentUserId,
               targetUserIdList,
               lastDocument,
             ],

--- a/test/feature/definition/application/definition_service_test.mocks.dart
+++ b/test/feature/definition/application/definition_service_test.mocks.dart
@@ -84,14 +84,16 @@ class MockDefinitionRepository extends _i1.Mock
       ) as _i2.FirebaseFirestore);
 
   @override
-  _i6.Future<_i3.DefinitionIdListState> fetchHomeRecommendDefinitionIdList(
+  _i6.Future<_i3.DefinitionIdListState> fetchHomeRecommendDefinitionIdListState(
+    String? currentUserId,
     List<String>? mutedUserIdList,
     _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchHomeRecommendDefinitionIdList,
+          #fetchHomeRecommendDefinitionIdListState,
           [
+            currentUserId,
             mutedUserIdList,
             lastDocument,
           ],
@@ -100,8 +102,9 @@ class MockDefinitionRepository extends _i1.Mock
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
-            #fetchHomeRecommendDefinitionIdList,
+            #fetchHomeRecommendDefinitionIdListState,
             [
+              currentUserId,
               mutedUserIdList,
               lastDocument,
             ],
@@ -111,8 +114,9 @@ class MockDefinitionRepository extends _i1.Mock
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
-            #fetchHomeRecommendDefinitionIdList,
+            #fetchHomeRecommendDefinitionIdListState,
             [
+              currentUserId,
               mutedUserIdList,
               lastDocument,
             ],
@@ -158,7 +162,7 @@ class MockDefinitionRepository extends _i1.Mock
       ) as _i6.Future<_i3.DefinitionIdListState>);
 
   @override
-  _i6.Future<_i3.DefinitionIdListState> fetchWordTopDefinitionIdList(
+  _i6.Future<_i3.DefinitionIdListState> fetchWordTopDefinitionIdListState(
     _i7.WordTopOrderByType? orderByType,
     String? currentUserId,
     List<String>? mutedUserIdList,
@@ -167,7 +171,7 @@ class MockDefinitionRepository extends _i1.Mock
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchWordTopDefinitionIdList,
+          #fetchWordTopDefinitionIdListState,
           [
             orderByType,
             currentUserId,
@@ -180,7 +184,7 @@ class MockDefinitionRepository extends _i1.Mock
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
-            #fetchWordTopDefinitionIdList,
+            #fetchWordTopDefinitionIdListState,
             [
               orderByType,
               currentUserId,
@@ -194,7 +198,7 @@ class MockDefinitionRepository extends _i1.Mock
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
-            #fetchWordTopDefinitionIdList,
+            #fetchWordTopDefinitionIdListState,
             [
               orderByType,
               currentUserId,

--- a/test/feature/definition/application/definition_state_test.mocks.dart
+++ b/test/feature/definition/application/definition_state_test.mocks.dart
@@ -166,6 +166,7 @@ class MockDefinitionRepository extends _i1.Mock
 
   @override
   _i9.Future<_i3.DefinitionIdListState> fetchHomeFollowingDefinitionIdList(
+    String? currentUserId,
     List<String>? targetUserIdList,
     _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
@@ -173,6 +174,7 @@ class MockDefinitionRepository extends _i1.Mock
         Invocation.method(
           #fetchHomeFollowingDefinitionIdList,
           [
+            currentUserId,
             targetUserIdList,
             lastDocument,
           ],
@@ -183,6 +185,7 @@ class MockDefinitionRepository extends _i1.Mock
           Invocation.method(
             #fetchHomeFollowingDefinitionIdList,
             [
+              currentUserId,
               targetUserIdList,
               lastDocument,
             ],
@@ -194,6 +197,7 @@ class MockDefinitionRepository extends _i1.Mock
           Invocation.method(
             #fetchHomeFollowingDefinitionIdList,
             [
+              currentUserId,
               targetUserIdList,
               lastDocument,
             ],

--- a/test/feature/definition/application/definition_state_test.mocks.dart
+++ b/test/feature/definition/application/definition_state_test.mocks.dart
@@ -124,14 +124,16 @@ class MockDefinitionRepository extends _i1.Mock
       ) as _i2.FirebaseFirestore);
 
   @override
-  _i9.Future<_i3.DefinitionIdListState> fetchHomeRecommendDefinitionIdList(
+  _i9.Future<_i3.DefinitionIdListState> fetchHomeRecommendDefinitionIdListState(
+    String? currentUserId,
     List<String>? mutedUserIdList,
     _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchHomeRecommendDefinitionIdList,
+          #fetchHomeRecommendDefinitionIdListState,
           [
+            currentUserId,
             mutedUserIdList,
             lastDocument,
           ],
@@ -140,8 +142,9 @@ class MockDefinitionRepository extends _i1.Mock
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
-            #fetchHomeRecommendDefinitionIdList,
+            #fetchHomeRecommendDefinitionIdListState,
             [
+              currentUserId,
               mutedUserIdList,
               lastDocument,
             ],
@@ -151,8 +154,9 @@ class MockDefinitionRepository extends _i1.Mock
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
-            #fetchHomeRecommendDefinitionIdList,
+            #fetchHomeRecommendDefinitionIdListState,
             [
+              currentUserId,
               mutedUserIdList,
               lastDocument,
             ],
@@ -198,7 +202,7 @@ class MockDefinitionRepository extends _i1.Mock
       ) as _i9.Future<_i3.DefinitionIdListState>);
 
   @override
-  _i9.Future<_i3.DefinitionIdListState> fetchWordTopDefinitionIdList(
+  _i9.Future<_i3.DefinitionIdListState> fetchWordTopDefinitionIdListState(
     _i10.WordTopOrderByType? orderByType,
     String? currentUserId,
     List<String>? mutedUserIdList,
@@ -207,7 +211,7 @@ class MockDefinitionRepository extends _i1.Mock
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchWordTopDefinitionIdList,
+          #fetchWordTopDefinitionIdListState,
           [
             orderByType,
             currentUserId,
@@ -220,7 +224,7 @@ class MockDefinitionRepository extends _i1.Mock
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
-            #fetchWordTopDefinitionIdList,
+            #fetchWordTopDefinitionIdListState,
             [
               orderByType,
               currentUserId,
@@ -234,7 +238,7 @@ class MockDefinitionRepository extends _i1.Mock
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
-            #fetchWordTopDefinitionIdList,
+            #fetchWordTopDefinitionIdListState,
             [
               orderByType,
               currentUserId,

--- a/test/feature/definition/application/definition_state_test.mocks.dart
+++ b/test/feature/definition/application/definition_state_test.mocks.dart
@@ -165,7 +165,7 @@ class MockDefinitionRepository extends _i1.Mock
       ) as _i9.Future<_i3.DefinitionIdListState>);
 
   @override
-  _i9.Future<_i3.DefinitionIdListState> fetchHomeFollowingDefinitionIdList(
+  _i9.Future<_i3.DefinitionIdListState> fetchHomeFollowingDefinitionIdListState(
     String? currentUserId,
     List<String>? targetUserIdList,
     _i2.QueryDocumentSnapshot<Object?>? lastDocument,


### PR DESCRIPTION
# 対象Issue

- #59 

# やった事

- ホーム画面で表示する定義一覧の取得処理を実装

# やらなかった事

# 動作確認

- iPhone11（実機）で、実装に問題がないことを確認

# その他

