### PR TITLE
Wordのreadingの頭文字を出力するロジックを修正

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -18,7 +18,7 @@ import '../../feature/word/presentation/page/index_top/index_top_page.dart';
 import '../../feature/word/presentation/page/search_word_result/search_word_result_page.dart';
 import '../../feature/word/presentation/page/word_list/word_list_page.dart';
 import '../../feature/word/presentation/page/word_top/word_top_page.dart';
-import '../../feature/word/util/initial_main_group.dart';
+import '../../util/constant/initial_main_group.dart';
 
 part 'app_router.g.dart';
 part 'app_router.gr.dart';

--- a/lib/feature/definition/application/definition_id_list_state.g.dart
+++ b/lib/feature/definition/application/definition_id_list_state.g.dart
@@ -7,7 +7,7 @@ part of 'definition_id_list_state.dart';
 // **************************************************************************
 
 String _$definitionIdListStateNotifierHash() =>
-    r'1a4936f2d0b182284e2a199fede6155fb125975e';
+    r'4804844313b4aa6a383887ae43c94debf1d278a5';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/feature/definition/domain/definition_for_write.dart
+++ b/lib/feature/definition/domain/definition_for_write.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../../../util/constant/firestore_collections.dart';
 import '../../../util/constant/initial_main_group.dart';
 import '../../../util/constant/string_regex.dart';
 
@@ -74,22 +75,22 @@ class DefinitionForWrite with _$DefinitionForWrite {
 
   Map<String, dynamic> toFirestoreForCreate() {
     return {
-      'word': word,
-      'wordReading': wordReading,
-      'wordReadingInitialSubGroupLabel': _wordReadingInitialLabel,
-      'definition': definition,
-      'likesCount': 0,
-      'isPublic': isPublic,
+      DefinitionsCollection.word: word,
+      DefinitionsCollection.wordReadingInitialSubGroupLabel:
+          _wordReadingInitialLabel,
+      DefinitionsCollection.definition: definition,
+      DefinitionsCollection.likesCount: 0,
+      DefinitionsCollection.isPublic: isPublic,
     };
   }
 
   Map<String, dynamic> toFirestoreForUpdate() {
     return {
-      'word': word,
-      'wordReading': wordReading,
-      'wordReadingInitialSubGroupLabel': _wordReadingInitialLabel,
-      'definition': definition,
-      'isPublic': isPublic,
+      DefinitionsCollection.word: word,
+      DefinitionsCollection.wordReadingInitialSubGroupLabel:
+          _wordReadingInitialLabel,
+      DefinitionsCollection.definition: definition,
+      DefinitionsCollection.isPublic: isPublic,
     };
   }
 

--- a/lib/feature/definition/domain/definition_for_write.dart
+++ b/lib/feature/definition/domain/definition_for_write.dart
@@ -1,5 +1,8 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../../../util/constant/initial_main_group.dart';
+import '../../../util/constant/string_regex.dart';
+
 part 'definition_for_write.freezed.dart';
 
 /// Definitionの新規投稿・更新時に使用するオブジェクト
@@ -42,11 +45,8 @@ class DefinitionForWrite with _$DefinitionForWrite {
       return _leadingSpaceErrorText;
     }
 
-    // 次の文字種別のみを共用する正規表現
-    // スペース、ひらがな、カタカナ、アルファベット（大文字・小文字）、数字、一部記号（'ー'含む）
-    final validPattern =
-        RegExp(r'^[ ぁ-んァ-ンa-zA-Z0-9!#$%&()*+,\-./:;<=>?@\[\]^_`{|}~\u30FC]+$');
-    if (!validPattern.hasMatch(wordReading)) {
+    // 文字が無効かどうか確認
+    if (!combinedRegex.hasMatch(wordReading)) {
       // 漢字が含まれているか確認
       final kanjiPattern = RegExp(r'[\u3400-\u9FBF]');
       if (kanjiPattern.hasMatch(wordReading)) {
@@ -76,7 +76,7 @@ class DefinitionForWrite with _$DefinitionForWrite {
     return {
       'word': word,
       'wordReading': wordReading,
-      'wordReadingInitialGroup': categorizeFirstCharacter(wordReading),
+      'wordReadingInitialSubGroupLabel': _wordReadingInitialLabel,
       'definition': definition,
       'likesCount': 0,
       'isPublic': isPublic,
@@ -87,46 +87,15 @@ class DefinitionForWrite with _$DefinitionForWrite {
     return {
       'word': word,
       'wordReading': wordReading,
-      'wordReadingInitialGroup': categorizeFirstCharacter(wordReading),
+      'wordReadingInitialSubGroupLabel': _wordReadingInitialLabel,
       'definition': definition,
       'isPublic': isPublic,
     };
   }
 
-  // 文字列（Unicode）が絡んでおり繊細な問題であること、
-  // データ取得時の絞り込み等で利用するため特に正確に値を保存したいことから、テストを作成する
-  @visibleForTesting
-  String categorizeFirstCharacter(String text) {
-    final firstChar = text.substring(0, 1);
-
-    // ひらがなの場合、そのまま返す
-    if (RegExp(r'^[ぁ-ん]').hasMatch(firstChar)) {
-      return firstChar;
-    }
-    // カタカナの場合、ひらがなに変換して返す
-    else if (RegExp(r'^[ァ-ヶー]').hasMatch(firstChar)) {
-      return _convertToHiragana(firstChar);
-    }
-    // アルファベットの場合、大文字に変換して返す
-    else if (RegExp(r'^[a-zA-Z]').hasMatch(firstChar)) {
-      return firstChar.toUpperCase();
-    }
-    // 数字の場合、「数字」を返す
-    else if (RegExp(r'^[0-9]').hasMatch(firstChar)) {
-      return '数字';
-    }
-    // それ以外の場合（記号など）、「記号」を返す
-    else {
-      return '記号';
-    }
-  }
-
-  String _convertToHiragana(String katakana) {
-    // Unicodeの範囲を利用してカタカナからひらがなに変換
-    final offset = 'ァ'.codeUnitAt(0) - 'ぁ'.codeUnitAt(0);
-    return String.fromCharCode(katakana.codeUnitAt(0) - offset);
-  }
-
   bool get isEmptyAllFields =>
       word.isEmpty && wordReading.isEmpty && definition.isEmpty;
+
+  String get _wordReadingInitialLabel =>
+      InitialSubGroup.labelFromString(wordReading);
 }

--- a/lib/feature/definition/repository/definition_repository.dart
+++ b/lib/feature/definition/repository/definition_repository.dart
@@ -5,6 +5,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/common_provider/firebase_providers.dart'; 
 import '../../../util/constant/config_constant.dart';
+import '../../../util/constant/initial_main_group.dart';
 import '../../../util/extension/firestore_extension.dart';
 import '../domain/definition_for_write.dart';
 import '../domain/definition_id_list_state.dart';
@@ -369,12 +370,11 @@ class DefinitionRepository {
   // Definitionドキュメントの作成/更新処理とバッチ実行する必要があるため、このクラスに作成している。
   /// Wordドキュメントを作成し、作成したドキュメントのidを返す。
   Future<String> _createWord(String word, String wordReading) async {
-    final initialLetter = wordReading.substring(0, 1);
     final docRef = await firestore.collection('Words').add(
       {
         'word': word,
         'reading': wordReading,
-        'initialLetter': initialLetter,
+        'initialSubGroupLabel': InitialSubGroup.labelFromString(wordReading),
         'createdAt': FieldValue.serverTimestamp(),
         'updatedAt': FieldValue.serverTimestamp(),
       },

--- a/lib/feature/definition/repository/definition_repository.dart
+++ b/lib/feature/definition/repository/definition_repository.dart
@@ -3,8 +3,9 @@ import 'dart:math';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../../../core/common_provider/firebase_providers.dart'; 
+import '../../../core/common_provider/firebase_providers.dart';
 import '../../../util/constant/config_constant.dart';
+import '../../../util/constant/firestore_collections.dart';
 import '../../../util/constant/initial_main_group.dart';
 import '../../../util/extension/firestore_extension.dart';
 import '../domain/definition_for_write.dart';
@@ -24,6 +25,15 @@ class DefinitionRepository {
   DefinitionRepository(this.firestore);
 
   final FirebaseFirestore firestore;
+
+  CollectionReference get _definitionsCollectionRef =>
+      firestore.collection(DefinitionsCollection.collectionName);
+
+  CollectionReference get _wordsCollectionRef =>
+      firestore.collection(WordsCollection.collectionName);
+
+  CollectionReference get _likesCollectionRef =>
+      firestore.collection(LikesCollection.collectionName);
 
   /// 「ホーム画面: おすすめタブ」で表示するDefinitionIDのListを取得する
   ///
@@ -52,15 +62,17 @@ class DefinitionRepository {
     QueryDocumentSnapshot? lastDocument,
     int fetchLimit,
   ) async {
-    var query = firestore
-        .collection('Definitions')
+    var query = _definitionsCollectionRef
         .where(
           Filter.or(
-            Filter('authorId', isEqualTo: currentUserId),
-            Filter('isPublic', isEqualTo: true),
+            Filter(
+              DefinitionsCollection.authorId,
+              isEqualTo: currentUserId,
+            ),
+            Filter(DefinitionsCollection.isPublic, isEqualTo: true),
           ),
         )
-        .orderBy('createdAt', descending: true)
+        .orderBy(createdAtFieldName, descending: true)
         .limit(fetchLimit);
 
     if (lastDocument != null) {
@@ -123,16 +135,18 @@ class DefinitionRepository {
     List<String> targetUserIdChunk,
     QueryDocumentSnapshot? lastDocument,
   ) async {
-    var query = firestore
-        .collection('Definitions')
-        .where('authorId', whereIn: targetUserIdChunk)
+    var query = _definitionsCollectionRef
+        .where(DefinitionsCollection.authorId, whereIn: targetUserIdChunk)
         .where(
           Filter.or(
-            Filter('authorId', isEqualTo: currentUserId),
-            Filter('isPublic', isEqualTo: true),
+            Filter(
+              DefinitionsCollection.authorId,
+              isEqualTo: currentUserId,
+            ),
+            Filter(DefinitionsCollection.isPublic, isEqualTo: true),
           ),
         )
-        .orderBy('createdAt', descending: true)
+        .orderBy(createdAtFieldName, descending: true)
         .limit(fetchLimitForDefinitionList);
 
     if (lastDocument != null) {
@@ -149,8 +163,8 @@ class DefinitionRepository {
   ) {
     // ソート処理
     documentList.sort((a, b) {
-      final timestampA = a.get('createdAt') as Timestamp;
-      final timestampB = b.get('createdAt') as Timestamp;
+      final timestampA = a.get(createdAtFieldName) as Timestamp;
+      final timestampB = b.get(createdAtFieldName) as Timestamp;
       return timestampB.toDate().compareTo(timestampA.toDate());
     });
     // 最初の`limit`件のドキュメントを取得
@@ -209,20 +223,22 @@ class DefinitionRepository {
     late final String orderByField;
     switch (orderByType) {
       case WordTopOrderByType.createdAt:
-        orderByField = 'createdAt';
+        orderByField = createdAtFieldName;
         break;
       case WordTopOrderByType.likesCount:
-        orderByField = 'likesCount';
+        orderByField = DefinitionsCollection.likesCount;
         break;
     }
 
-    var query = firestore
-        .collection('Definitions')
-        .where('wordId', isEqualTo: wordId)
+    var query = _definitionsCollectionRef
+        .where(DefinitionsCollection.wordId, isEqualTo: wordId)
         .where(
           Filter.or(
-            Filter('authorId', isEqualTo: currentUserId),
-            Filter('isPublic', isEqualTo: true),
+            Filter(
+              DefinitionsCollection.authorId,
+              isEqualTo: currentUserId,
+            ),
+            Filter(DefinitionsCollection.isPublic, isEqualTo: true),
           ),
         )
         .orderBy(orderByField, descending: true)
@@ -286,8 +302,7 @@ class DefinitionRepository {
   }
 
   Future<DefinitionDocument> fetchDefinition(String definitionId) async {
-    final snapshot = await firestore
-        .collection('Definitions')
+    final snapshot = await _definitionsCollectionRef
         .doc(definitionId)
         .get()
         .then((snapshot) => snapshot);
@@ -323,12 +338,12 @@ class DefinitionRepository {
     String wordId,
     DefinitionForWrite definitionForWrite,
   ) async {
-    await firestore.collection('Definitions').add({
+    await _definitionsCollectionRef.add({
       ...definitionForWrite.toFirestoreForCreate(),
-      'authorId': authorId,
-      'wordId': wordId,
-      'createdAt': FieldValue.serverTimestamp(),
-      'updatedAt': FieldValue.serverTimestamp(),
+      DefinitionsCollection.authorId: authorId,
+      DefinitionsCollection.wordId: wordId,
+      createdAtFieldName: FieldValue.serverTimestamp(),
+      updatedAtFieldName: FieldValue.serverTimestamp(),
     });
   }
 
@@ -358,11 +373,11 @@ class DefinitionRepository {
     String wordId,
     DefinitionForWrite definitionForWrite,
   ) async {
-    await firestore.collection('Definitions').doc(definitionForWrite.id).update(
+    await _definitionsCollectionRef.doc(definitionForWrite.id).update(
       {
         ...definitionForWrite.toFirestoreForUpdate(),
-        'wordId': wordId,
-        'updatedAt': FieldValue.serverTimestamp(),
+        DefinitionsCollection.wordId: wordId,
+        updatedAtFieldName: FieldValue.serverTimestamp(),
       },
     );
   }
@@ -370,13 +385,14 @@ class DefinitionRepository {
   // Definitionドキュメントの作成/更新処理とバッチ実行する必要があるため、このクラスに作成している。
   /// Wordドキュメントを作成し、作成したドキュメントのidを返す。
   Future<String> _createWord(String word, String wordReading) async {
-    final docRef = await firestore.collection('Words').add(
+    final docRef = await _wordsCollectionRef.add(
       {
-        'word': word,
-        'reading': wordReading,
-        'initialSubGroupLabel': InitialSubGroup.labelFromString(wordReading),
-        'createdAt': FieldValue.serverTimestamp(),
-        'updatedAt': FieldValue.serverTimestamp(),
+        WordsCollection.word: word,
+        WordsCollection.reading: wordReading,
+        WordsCollection.initialSubGroupLabel:
+            InitialSubGroup.labelFromString(wordReading),
+        createdAtFieldName: FieldValue.serverTimestamp(),
+        updatedAtFieldName: FieldValue.serverTimestamp(),
       },
     );
 
@@ -387,19 +403,18 @@ class DefinitionRepository {
     // transactionを使い、複数の処理が全て成功した場合のみ、処理を完了させる
     await firestore.runTransaction((transaction) async {
       // Likesコレクションにドキュメントを登録
-      final likesCollection = firestore.collection('Likes');
+      final likesCollection = _likesCollectionRef;
       transaction.set(likesCollection.doc(), {
-        'definitionId': definitionId,
-        'userId': userId,
-        'createdAt': FieldValue.serverTimestamp(),
-        'updatedAt': FieldValue.serverTimestamp(),
+        LikesCollection.definitionId: definitionId,
+        LikesCollection.userId: userId,
+        createdAtFieldName: FieldValue.serverTimestamp(),
+        updatedAtFieldName: FieldValue.serverTimestamp(),
       });
 
       // DefinitionコレクションからドキュメントのlikesCountを+1する
-      final definitionDocRef =
-          firestore.collection('Definitions').doc(definitionId);
+      final definitionDocRef = _definitionsCollectionRef.doc(definitionId);
       transaction.update(definitionDocRef, {
-        'likesCount': FieldValue.increment(1),
+        DefinitionsCollection.likesCount: FieldValue.increment(1),
       });
     });
   }
@@ -407,10 +422,9 @@ class DefinitionRepository {
   Future<void> unlikeDefinition(String definitionId, String userId) async {
     await firestore.runTransaction((transaction) async {
       // Likesコレクションからドキュメントを取得して削除
-      final likeSnapshot = await firestore
-          .collection('Likes')
-          .where('definitionId', isEqualTo: definitionId)
-          .where('userId', isEqualTo: userId)
+      final likeSnapshot = await _likesCollectionRef
+          .where(LikesCollection.definitionId, isEqualTo: definitionId)
+          .where(LikesCollection.userId, isEqualTo: userId)
           .get()
           .then((snapshot) => snapshot.docs.firstOrNull);
 
@@ -421,19 +435,17 @@ class DefinitionRepository {
       transaction.delete(likeSnapshot.reference);
 
       // DefinitionコレクションからドキュメントのlikesCountを-1する
-      final definitionDocRef =
-          firestore.collection('Definitions').doc(definitionId);
+      final definitionDocRef = _definitionsCollectionRef.doc(definitionId);
       transaction.update(definitionDocRef, {
-        'likesCount': FieldValue.increment(-1),
+        DefinitionsCollection.likesCount: FieldValue.increment(-1),
       });
     });
   }
 
   Future<bool> isLikedByUser(String userId, String definitionId) async {
-    final likeSnapshot = await firestore
-        .collection('Likes')
-        .where('definitionId', isEqualTo: definitionId)
-        .where('userId', isEqualTo: userId)
+    final likeSnapshot = await _likesCollectionRef
+        .where(LikesCollection.definitionId, isEqualTo: definitionId)
+        .where(LikesCollection.userId, isEqualTo: userId)
         .get()
         .then((snapshot) => snapshot.docs.firstOrNull);
 

--- a/lib/feature/definition/repository/entity/definition_document.dart
+++ b/lib/feature/definition/repository/entity/definition_document.dart
@@ -1,6 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../../../../util/constant/firestore_collections.dart';
+
 part 'definition_document.freezed.dart';
 
 @freezed
@@ -20,13 +22,13 @@ class DefinitionDocument with _$DefinitionDocument {
     final data = doc.data()! as Map<String, dynamic>;
     return DefinitionDocument(
       id: doc.id,
-      wordId: data['wordId'] as String,
-      authorId: data['authorId'] as String,
-      definition: data['definition'] as String,
-      likesCount: data['likesCount'] as int,
-      isPublic: data['isPublic'] as bool,
-      createdAt: (data['createdAt'] as Timestamp).toDate(),
-      updatedAt: (data['updatedAt'] as Timestamp).toDate(),
+      wordId: data[DefinitionsCollection.wordId] as String,
+      authorId: data[DefinitionsCollection.authorId] as String,
+      definition: data[DefinitionsCollection.definition] as String,
+      likesCount: data[DefinitionsCollection.likesCount] as int,
+      isPublic: data[DefinitionsCollection.isPublic] as bool,
+      createdAt: (data[createdAtFieldName] as Timestamp).toDate(),
+      updatedAt: (data[updatedAtFieldName] as Timestamp).toDate(),
     );
   }
 }

--- a/lib/feature/definition/repository/entity/like_document.dart
+++ b/lib/feature/definition/repository/entity/like_document.dart
@@ -1,6 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../../../../util/constant/firestore_collections.dart';
+
 part 'like_document.freezed.dart';
 
 @freezed
@@ -17,10 +19,10 @@ class LikeDocument with _$LikeDocument {
     final data = doc.data()! as Map<String, dynamic>;
     return LikeDocument(
       id: doc.id,
-      definitionId: data['definitionId'] as String,
-      userId: data['userId'] as String,
-      createdAt: (data['createdAt'] as Timestamp).toDate(),
-      updatedAt: (data['updatedAt'] as Timestamp).toDate(),
+      definitionId: data[LikesCollection.definitionId] as String,
+      userId: data[LikesCollection.userId] as String,
+      createdAt: (data[createdAtFieldName] as Timestamp).toDate(),
+      updatedAt: (data[updatedAtFieldName] as Timestamp).toDate(),
     );
   }
 }

--- a/lib/feature/user_config/repository/entity/user_config_document.dart
+++ b/lib/feature/user_config/repository/entity/user_config_document.dart
@@ -1,6 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../../../../util/constant/firestore_collections.dart';
+
 part 'user_config_document.freezed.dart';
 
 @freezed
@@ -18,13 +20,13 @@ class UserConfigDocument with _$UserConfigDocument {
     final data = doc.data()! as Map<String, dynamic>;
     return UserConfigDocument(
       id: doc.id,
-      appVersion: data['appVersion'] as String,
-      osVersion: data['osVersion'] as String,
-      mutedUserIdList: ((data['mutedUserIdList']) as List<dynamic>)
+      appVersion: data[UserConfigsCollection.appVersion] as String,
+      osVersion: data[UserConfigsCollection.osVersion] as String,
+      mutedUserIdList: ((data[UserConfigsCollection.mutedUserIdList]) as List<dynamic>)
           .map((e) => e as String)
           .toList(),
-      createdAt: (data['createdAt'] as Timestamp).toDate(),
-      updatedAt: (data['updatedAt'] as Timestamp).toDate(),
+      createdAt: (data[createdAtFieldName] as Timestamp).toDate(),
+      updatedAt: (data[updatedAtFieldName] as Timestamp).toDate(),
     );
   }
 }

--- a/lib/feature/user_config/repository/user_config_repository.dart
+++ b/lib/feature/user_config/repository/user_config_repository.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/common_provider/firebase_providers.dart';
+import '../../../util/constant/firestore_collections.dart';
 import 'entity/user_config_document.dart';
 
 part 'user_config_repository.g.dart';
@@ -17,9 +18,11 @@ class UserConfigRepository {
 
   final FirebaseFirestore firestore;
 
+  CollectionReference get _userConfigsCollectionRef =>
+      firestore.collection(UserConfigsCollection.collectionName);
+
   Future<UserConfigDocument> fetchUserConfig(String userId) async {
-    final DocumentSnapshot snapshot =
-        await firestore.collection('UserConfigs').doc(userId).get();
+    final snapshot = await _userConfigsCollectionRef.doc(userId).get();
 
     return UserConfigDocument.fromFirestore(snapshot);
   }
@@ -29,12 +32,12 @@ class UserConfigRepository {
     String osVersion,
     String appVersion,
   ) async {
-    await firestore.collection('UserConfigs').doc(userId).set({
-      'mutedUserIdList': <dynamic>[],
-      'osVersion': osVersion,
-      'appVersion': appVersion,
-      'createdAt': FieldValue.serverTimestamp(),
-      'updatedAt': FieldValue.serverTimestamp(),
+    await _userConfigsCollectionRef.doc(userId).set({
+      UserConfigsCollection.mutedUserIdList: <dynamic>[],
+      UserConfigsCollection.osVersion: osVersion,
+      UserConfigsCollection.appVersion: appVersion,
+      createdAtFieldName: FieldValue.serverTimestamp(),
+      updatedAtFieldName: FieldValue.serverTimestamp(),
     });
   }
 
@@ -44,10 +47,10 @@ class UserConfigRepository {
     String osVersion,
     String appVersion,
   ) async {
-    await firestore.collection('UserConfigs').doc(userId).update({
-      'osVersion': osVersion,
-      'appVersion': appVersion,
-      'updatedAt': FieldValue.serverTimestamp(),
+    await _userConfigsCollectionRef.doc(userId).update({
+      UserConfigsCollection.osVersion: osVersion,
+      UserConfigsCollection.appVersion: appVersion,
+      updatedAtFieldName: FieldValue.serverTimestamp(),
     });
   }
 
@@ -56,9 +59,10 @@ class UserConfigRepository {
     String userId,
     String mutedUserId,
   ) async {
-    await firestore.collection('UserConfigs').doc(userId).update({
-      'mutedUserIdList': FieldValue.arrayUnion(<dynamic>[mutedUserId]),
-      'updatedAt': FieldValue.serverTimestamp(),
+    await _userConfigsCollectionRef.doc(userId).update({
+      UserConfigsCollection.mutedUserIdList:
+          FieldValue.arrayUnion(<dynamic>[mutedUserId]),
+      updatedAtFieldName: FieldValue.serverTimestamp(),
     });
   }
 
@@ -67,9 +71,10 @@ class UserConfigRepository {
     String userId,
     String mutedUserId,
   ) async {
-    await firestore.collection('UserConfigs').doc(userId).update({
-      'mutedUserIdList': FieldValue.arrayRemove(<dynamic>[mutedUserId]),
-      'updatedAt': FieldValue.serverTimestamp(),
+    await _userConfigsCollectionRef.doc(userId).update({
+      UserConfigsCollection.mutedUserIdList:
+          FieldValue.arrayRemove(<dynamic>[mutedUserId]),
+      updatedAtFieldName: FieldValue.serverTimestamp(),
     });
   }
 }

--- a/lib/feature/user_profile/repository/entity/user_follow_count_document.dart
+++ b/lib/feature/user_profile/repository/entity/user_follow_count_document.dart
@@ -1,6 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../../../../util/constant/firestore_collections.dart';
+
 part 'user_follow_count_document.freezed.dart';
 
 @freezed
@@ -17,10 +19,10 @@ class UserFollowCountDocument with _$UserFollowCountDocument {
     final data = doc.data()! as Map<String, dynamic>;
     return UserFollowCountDocument(
       id: doc.id,
-      followerCount: data['followerCount'] as int,
-      followingCount: data['followingCount'] as int,
-      createdAt: (data['createdAt'] as Timestamp).toDate(),
-      updatedAt: (data['updatedAt'] as Timestamp).toDate(),
+      followerCount: data[UserFollowCountsCollection.followerCount] as int,
+      followingCount: data[UserFollowCountsCollection.followingCount] as int,
+      createdAt: (data[createdAtFieldName] as Timestamp).toDate(),
+      updatedAt: (data[updatedAtFieldName] as Timestamp).toDate(),
     );
   }
 }

--- a/lib/feature/user_profile/repository/entity/user_follow_document.dart
+++ b/lib/feature/user_profile/repository/entity/user_follow_document.dart
@@ -1,6 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../../../../util/constant/firestore_collections.dart';
+
 part 'user_follow_document.freezed.dart';
 
 @freezed
@@ -17,10 +19,10 @@ class UserFollowDocument with _$UserFollowDocument {
     final data = doc.data()! as Map<String, dynamic>;
     return UserFollowDocument(
       id: doc.id,
-      followerId: data['followerId'] as String,
-      followingId: data['followingId'] as String,
-      createdAt: (data['createdAt'] as Timestamp).toDate(),
-      updatedAt: (data['updatedAt'] as Timestamp).toDate(),
+      followerId: data[UserFollowsCollection.followerId] as String,
+      followingId: data[UserFollowsCollection.followingId] as String,
+      createdAt: (data[createdAtFieldName] as Timestamp).toDate(),
+      updatedAt: (data[updatedAtFieldName] as Timestamp).toDate(),
     );
   }
 }

--- a/lib/feature/user_profile/repository/entity/user_profile_document.dart
+++ b/lib/feature/user_profile/repository/entity/user_profile_document.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import '../../../../util/constant/default_value.dart';
+import '../../../../util/constant/firestore_collections.dart';
 
 part 'user_profile_document.freezed.dart';
 
@@ -20,11 +21,13 @@ class UserProfileDocument with _$UserProfileDocument {
     final data = doc.data()! as Map<String, dynamic>;
     return UserProfileDocument(
       id: doc.id,
-      name: data['name'] as String,
-      bio: data['bio'] as String,
-      profileImageUrl: data['profileImageUrl'] as String? ?? defaultImageUrl,
-      createdAt: (data['createdAt'] as Timestamp).toDate(),
-      updatedAt: (data['updatedAt'] as Timestamp).toDate(),
+      name: data[UserProfilesCollection.name] as String,
+      bio: data[UserProfilesCollection.bio] as String,
+      profileImageUrl:
+          data[UserProfilesCollection.profileImageUrl] as String? ??
+              defaultImageUrl,
+      createdAt: (data[createdAtFieldName] as Timestamp).toDate(),
+      updatedAt: (data[updatedAtFieldName] as Timestamp).toDate(),
     );
   }
 }

--- a/lib/feature/user_profile/repository/user_profile_repository.dart
+++ b/lib/feature/user_profile/repository/user_profile_repository.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/common_provider/firebase_providers.dart';
+import '../../../util/constant/firestore_collections.dart';
 import 'entity/user_profile_document.dart';
 
 part 'user_profile_repository.g.dart';
@@ -15,22 +16,24 @@ UserProfileRepository userProfileRepository(UserProfileRepositoryRef ref) =>
 class UserProfileRepository {
   UserProfileRepository(this.firestore);
 
+  CollectionReference get _userProfilesCollectionRef =>
+      firestore.collection(UserProfilesCollection.collectionName);
+
   final FirebaseFirestore firestore;
 
   Future<UserProfileDocument> fetchUserProfile(String userId) async {
-    final DocumentSnapshot snapshot =
-        await firestore.collection('UserProfiles').doc(userId).get();
+    final snapshot = await _userProfilesCollectionRef.doc(userId).get();
 
     return UserProfileDocument.fromFirestore(snapshot);
   }
 
   Future<void> addUserProfile(String userId, String name) async {
-    await firestore.collection('UserProfiles').doc(userId).set({
-      'name': name,
-      'bio': '',
-      'profileImageUrl': '',
-      'createdAt': FieldValue.serverTimestamp(),
-      'updatedAt': FieldValue.serverTimestamp(),
+    await _userProfilesCollectionRef.doc(userId).set({
+      UserProfilesCollection.name: name,
+      UserProfilesCollection.bio: '',
+      UserProfilesCollection.profileImageUrl: '',
+      createdAtFieldName: FieldValue.serverTimestamp(),
+      updatedAtFieldName: FieldValue.serverTimestamp(),
     });
   }
 }

--- a/lib/feature/word/application/word_state.dart
+++ b/lib/feature/word/application/word_state.dart
@@ -25,7 +25,7 @@ Future<Word> word(WordRef ref, String wordId) async {
     id: wordDoc.id,
     word: wordDoc.word,
     reading: wordDoc.reading,
-    initialLetter: wordDoc.initialLetter,
+    initialSubGroupLabel: wordDoc.initialSubGroupLabel,
     postedDefinitionCount: postedDefinitionCount,
   );
 }

--- a/lib/feature/word/application/word_state.g.dart
+++ b/lib/feature/word/application/word_state.g.dart
@@ -6,7 +6,7 @@ part of 'word_state.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$wordHash() => r'c1737801bfc13da1bae7012eaec2c6c6d7b8b931';
+String _$wordHash() => r'b2210ba303039f93528ea5103948deedfdf75a3c';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/feature/word/domain/word.dart
+++ b/lib/feature/word/domain/word.dart
@@ -8,7 +8,7 @@ class Word with _$Word {
     required String id,
     required String word,
     required String reading,
-    required String initialLetter,
+    required String initialSubGroupLabel,
     required int postedDefinitionCount,
   }) = _Word;
 }

--- a/lib/feature/word/domain/word.freezed.dart
+++ b/lib/feature/word/domain/word.freezed.dart
@@ -19,7 +19,7 @@ mixin _$Word {
   String get id => throw _privateConstructorUsedError;
   String get word => throw _privateConstructorUsedError;
   String get reading => throw _privateConstructorUsedError;
-  String get initialLetter => throw _privateConstructorUsedError;
+  String get initialSubGroupLabel => throw _privateConstructorUsedError;
   int get postedDefinitionCount => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
@@ -35,7 +35,7 @@ abstract class $WordCopyWith<$Res> {
       {String id,
       String word,
       String reading,
-      String initialLetter,
+      String initialSubGroupLabel,
       int postedDefinitionCount});
 }
 
@@ -55,7 +55,7 @@ class _$WordCopyWithImpl<$Res, $Val extends Word>
     Object? id = null,
     Object? word = null,
     Object? reading = null,
-    Object? initialLetter = null,
+    Object? initialSubGroupLabel = null,
     Object? postedDefinitionCount = null,
   }) {
     return _then(_value.copyWith(
@@ -71,9 +71,9 @@ class _$WordCopyWithImpl<$Res, $Val extends Word>
           ? _value.reading
           : reading // ignore: cast_nullable_to_non_nullable
               as String,
-      initialLetter: null == initialLetter
-          ? _value.initialLetter
-          : initialLetter // ignore: cast_nullable_to_non_nullable
+      initialSubGroupLabel: null == initialSubGroupLabel
+          ? _value.initialSubGroupLabel
+          : initialSubGroupLabel // ignore: cast_nullable_to_non_nullable
               as String,
       postedDefinitionCount: null == postedDefinitionCount
           ? _value.postedDefinitionCount
@@ -93,7 +93,7 @@ abstract class _$$_WordCopyWith<$Res> implements $WordCopyWith<$Res> {
       {String id,
       String word,
       String reading,
-      String initialLetter,
+      String initialSubGroupLabel,
       int postedDefinitionCount});
 }
 
@@ -109,7 +109,7 @@ class __$$_WordCopyWithImpl<$Res> extends _$WordCopyWithImpl<$Res, _$_Word>
     Object? id = null,
     Object? word = null,
     Object? reading = null,
-    Object? initialLetter = null,
+    Object? initialSubGroupLabel = null,
     Object? postedDefinitionCount = null,
   }) {
     return _then(_$_Word(
@@ -125,9 +125,9 @@ class __$$_WordCopyWithImpl<$Res> extends _$WordCopyWithImpl<$Res, _$_Word>
           ? _value.reading
           : reading // ignore: cast_nullable_to_non_nullable
               as String,
-      initialLetter: null == initialLetter
-          ? _value.initialLetter
-          : initialLetter // ignore: cast_nullable_to_non_nullable
+      initialSubGroupLabel: null == initialSubGroupLabel
+          ? _value.initialSubGroupLabel
+          : initialSubGroupLabel // ignore: cast_nullable_to_non_nullable
               as String,
       postedDefinitionCount: null == postedDefinitionCount
           ? _value.postedDefinitionCount
@@ -144,7 +144,7 @@ class _$_Word implements _Word {
       {required this.id,
       required this.word,
       required this.reading,
-      required this.initialLetter,
+      required this.initialSubGroupLabel,
       required this.postedDefinitionCount});
 
   @override
@@ -154,13 +154,13 @@ class _$_Word implements _Word {
   @override
   final String reading;
   @override
-  final String initialLetter;
+  final String initialSubGroupLabel;
   @override
   final int postedDefinitionCount;
 
   @override
   String toString() {
-    return 'Word(id: $id, word: $word, reading: $reading, initialLetter: $initialLetter, postedDefinitionCount: $postedDefinitionCount)';
+    return 'Word(id: $id, word: $word, reading: $reading, initialSubGroupLabel: $initialSubGroupLabel, postedDefinitionCount: $postedDefinitionCount)';
   }
 
   @override
@@ -171,15 +171,15 @@ class _$_Word implements _Word {
             (identical(other.id, id) || other.id == id) &&
             (identical(other.word, word) || other.word == word) &&
             (identical(other.reading, reading) || other.reading == reading) &&
-            (identical(other.initialLetter, initialLetter) ||
-                other.initialLetter == initialLetter) &&
+            (identical(other.initialSubGroupLabel, initialSubGroupLabel) ||
+                other.initialSubGroupLabel == initialSubGroupLabel) &&
             (identical(other.postedDefinitionCount, postedDefinitionCount) ||
                 other.postedDefinitionCount == postedDefinitionCount));
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType, id, word, reading, initialLetter, postedDefinitionCount);
+  int get hashCode => Object.hash(runtimeType, id, word, reading,
+      initialSubGroupLabel, postedDefinitionCount);
 
   @JsonKey(ignore: true)
   @override
@@ -193,7 +193,7 @@ abstract class _Word implements Word {
       {required final String id,
       required final String word,
       required final String reading,
-      required final String initialLetter,
+      required final String initialSubGroupLabel,
       required final int postedDefinitionCount}) = _$_Word;
 
   @override
@@ -203,7 +203,7 @@ abstract class _Word implements Word {
   @override
   String get reading;
   @override
-  String get initialLetter;
+  String get initialSubGroupLabel;
   @override
   int get postedDefinitionCount;
   @override

--- a/lib/feature/word/presentation/page/index_second/index_second_page.dart
+++ b/lib/feature/word/presentation/page/index_second/index_second_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 
 import '../../../../../core/common_widget/button/back_icon_button.dart';
 import '../../../../../core/router/app_router.dart';
-import '../../../util/initial_main_group.dart';
+import '../../../../../util/constant/initial_main_group.dart';
 import '../../component/index_tile.dart';
 
 @RoutePage()

--- a/lib/feature/word/presentation/page/index_top/index_top_page.dart
+++ b/lib/feature/word/presentation/page/index_top/index_top_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 
 import '../../../../../core/common_widget/button/to_setting_button.dart';
 import '../../../../../core/router/app_router.dart';
-import '../../../util/initial_main_group.dart';
+import '../../../../../util/constant/initial_main_group.dart';
 import '../../component/index_tile.dart';
 import 'word_search_text_field.dart';
 

--- a/lib/feature/word/presentation/page/word_list/word_list_page.dart
+++ b/lib/feature/word/presentation/page/word_list/word_list_page.dart
@@ -6,9 +6,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../../core/common_widget/button/back_icon_button.dart';
 import '../../../../../core/common_widget/cupertino_refresh_indicator.dart';
 import '../../../../../core/common_widget/infinite_scroll_bottom_indicator.dart';
+import '../../../../../util/constant/initial_main_group.dart';
 import '../../../../../util/logger.dart';
 import '../../../application/word_list_state_by_initial.dart';
-import '../../../util/initial_main_group.dart';
 import '../../component/word_tile.dart';
 
 @RoutePage()

--- a/lib/feature/word/repository/entity/word_document.dart
+++ b/lib/feature/word/repository/entity/word_document.dart
@@ -9,7 +9,7 @@ class WordDocument with _$WordDocument {
     required String id,
     required String word,
     required String reading,
-    required String initialLetter,
+    required String initialSubGroupLabel,
     required DateTime createdAt,
     required DateTime updatedAt,
   }) = _WordDocument;
@@ -20,7 +20,7 @@ class WordDocument with _$WordDocument {
       id: doc.id,
       word: data['word'] as String,
       reading: data['reading'] as String,
-      initialLetter: data['initialLetter'] as String,
+      initialSubGroupLabel: data['initialSubGroupLabel'] as String,
       createdAt: (data['createdAt'] as Timestamp).toDate(),
       updatedAt: (data['updatedAt'] as Timestamp).toDate(),
     );

--- a/lib/feature/word/repository/entity/word_document.dart
+++ b/lib/feature/word/repository/entity/word_document.dart
@@ -1,6 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../../../../util/constant/firestore_collections.dart';
+
 part 'word_document.freezed.dart';
 
 @freezed
@@ -18,11 +20,12 @@ class WordDocument with _$WordDocument {
     final data = doc.data()! as Map<String, dynamic>;
     return WordDocument(
       id: doc.id,
-      word: data['word'] as String,
-      reading: data['reading'] as String,
-      initialSubGroupLabel: data['initialSubGroupLabel'] as String,
-      createdAt: (data['createdAt'] as Timestamp).toDate(),
-      updatedAt: (data['updatedAt'] as Timestamp).toDate(),
+      word: data[WordsCollection.word] as String,
+      reading: data[WordsCollection.reading] as String,
+      initialSubGroupLabel:
+          data[WordsCollection.initialSubGroupLabel] as String,
+      createdAt: (data[createdAtFieldName] as Timestamp).toDate(),
+      updatedAt: (data[updatedAtFieldName] as Timestamp).toDate(),
     );
   }
 }

--- a/lib/feature/word/repository/entity/word_document.freezed.dart
+++ b/lib/feature/word/repository/entity/word_document.freezed.dart
@@ -19,7 +19,7 @@ mixin _$WordDocument {
   String get id => throw _privateConstructorUsedError;
   String get word => throw _privateConstructorUsedError;
   String get reading => throw _privateConstructorUsedError;
-  String get initialLetter => throw _privateConstructorUsedError;
+  String get initialSubGroupLabel => throw _privateConstructorUsedError;
   DateTime get createdAt => throw _privateConstructorUsedError;
   DateTime get updatedAt => throw _privateConstructorUsedError;
 
@@ -38,7 +38,7 @@ abstract class $WordDocumentCopyWith<$Res> {
       {String id,
       String word,
       String reading,
-      String initialLetter,
+      String initialSubGroupLabel,
       DateTime createdAt,
       DateTime updatedAt});
 }
@@ -59,7 +59,7 @@ class _$WordDocumentCopyWithImpl<$Res, $Val extends WordDocument>
     Object? id = null,
     Object? word = null,
     Object? reading = null,
-    Object? initialLetter = null,
+    Object? initialSubGroupLabel = null,
     Object? createdAt = null,
     Object? updatedAt = null,
   }) {
@@ -76,9 +76,9 @@ class _$WordDocumentCopyWithImpl<$Res, $Val extends WordDocument>
           ? _value.reading
           : reading // ignore: cast_nullable_to_non_nullable
               as String,
-      initialLetter: null == initialLetter
-          ? _value.initialLetter
-          : initialLetter // ignore: cast_nullable_to_non_nullable
+      initialSubGroupLabel: null == initialSubGroupLabel
+          ? _value.initialSubGroupLabel
+          : initialSubGroupLabel // ignore: cast_nullable_to_non_nullable
               as String,
       createdAt: null == createdAt
           ? _value.createdAt
@@ -104,7 +104,7 @@ abstract class _$$_WordDocumentCopyWith<$Res>
       {String id,
       String word,
       String reading,
-      String initialLetter,
+      String initialSubGroupLabel,
       DateTime createdAt,
       DateTime updatedAt});
 }
@@ -123,7 +123,7 @@ class __$$_WordDocumentCopyWithImpl<$Res>
     Object? id = null,
     Object? word = null,
     Object? reading = null,
-    Object? initialLetter = null,
+    Object? initialSubGroupLabel = null,
     Object? createdAt = null,
     Object? updatedAt = null,
   }) {
@@ -140,9 +140,9 @@ class __$$_WordDocumentCopyWithImpl<$Res>
           ? _value.reading
           : reading // ignore: cast_nullable_to_non_nullable
               as String,
-      initialLetter: null == initialLetter
-          ? _value.initialLetter
-          : initialLetter // ignore: cast_nullable_to_non_nullable
+      initialSubGroupLabel: null == initialSubGroupLabel
+          ? _value.initialSubGroupLabel
+          : initialSubGroupLabel // ignore: cast_nullable_to_non_nullable
               as String,
       createdAt: null == createdAt
           ? _value.createdAt
@@ -163,7 +163,7 @@ class _$_WordDocument implements _WordDocument {
       {required this.id,
       required this.word,
       required this.reading,
-      required this.initialLetter,
+      required this.initialSubGroupLabel,
       required this.createdAt,
       required this.updatedAt});
 
@@ -174,7 +174,7 @@ class _$_WordDocument implements _WordDocument {
   @override
   final String reading;
   @override
-  final String initialLetter;
+  final String initialSubGroupLabel;
   @override
   final DateTime createdAt;
   @override
@@ -182,7 +182,7 @@ class _$_WordDocument implements _WordDocument {
 
   @override
   String toString() {
-    return 'WordDocument(id: $id, word: $word, reading: $reading, initialLetter: $initialLetter, createdAt: $createdAt, updatedAt: $updatedAt)';
+    return 'WordDocument(id: $id, word: $word, reading: $reading, initialSubGroupLabel: $initialSubGroupLabel, createdAt: $createdAt, updatedAt: $updatedAt)';
   }
 
   @override
@@ -193,8 +193,8 @@ class _$_WordDocument implements _WordDocument {
             (identical(other.id, id) || other.id == id) &&
             (identical(other.word, word) || other.word == word) &&
             (identical(other.reading, reading) || other.reading == reading) &&
-            (identical(other.initialLetter, initialLetter) ||
-                other.initialLetter == initialLetter) &&
+            (identical(other.initialSubGroupLabel, initialSubGroupLabel) ||
+                other.initialSubGroupLabel == initialSubGroupLabel) &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             (identical(other.updatedAt, updatedAt) ||
@@ -202,8 +202,8 @@ class _$_WordDocument implements _WordDocument {
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType, id, word, reading, initialLetter, createdAt, updatedAt);
+  int get hashCode => Object.hash(runtimeType, id, word, reading,
+      initialSubGroupLabel, createdAt, updatedAt);
 
   @JsonKey(ignore: true)
   @override
@@ -217,7 +217,7 @@ abstract class _WordDocument implements WordDocument {
       {required final String id,
       required final String word,
       required final String reading,
-      required final String initialLetter,
+      required final String initialSubGroupLabel,
       required final DateTime createdAt,
       required final DateTime updatedAt}) = _$_WordDocument;
 
@@ -228,7 +228,7 @@ abstract class _WordDocument implements WordDocument {
   @override
   String get reading;
   @override
-  String get initialLetter;
+  String get initialSubGroupLabel;
   @override
   DateTime get createdAt;
   @override

--- a/lib/feature/word/repository/word_repository.dart
+++ b/lib/feature/word/repository/word_repository.dart
@@ -3,6 +3,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/common_provider/firebase_providers.dart';
 import '../../../util/constant/config_constant.dart';
+import '../../../util/constant/firestore_collections.dart';
 import '../domain/word.dart';
 import '../domain/word_list_state.dart';
 import 'entity/word_document.dart';
@@ -19,9 +20,14 @@ class WordRepository {
 
   final FirebaseFirestore firestore;
 
+  CollectionReference get _wordsCollectionRef =>
+      firestore.collection(WordsCollection.collectionName);
+
+  CollectionReference get _definitionsCollectionRef =>
+      firestore.collection(DefinitionsCollection.collectionName);
+
   Future<WordDocument> fetchWordById(String wordId) async {
-    final DocumentSnapshot snapshot =
-        await firestore.collection('Words').doc(wordId).get();
+    final snapshot = await _wordsCollectionRef.doc(wordId).get();
 
     return WordDocument.fromFirestore(snapshot);
   }
@@ -30,10 +36,9 @@ class WordRepository {
   ///
   /// 見つからない場合はnullを返す
   Future<String?> findWordId(String word, String wordReading) async {
-    final snapshot = await firestore
-        .collection('Words')
-        .where('word', isEqualTo: word)
-        .where('reading', isEqualTo: wordReading)
+    final snapshot = await _wordsCollectionRef
+        .where(WordsCollection.word, isEqualTo: word)
+        .where(WordsCollection.reading, isEqualTo: wordReading)
         .limit(1)
         .get();
 
@@ -127,10 +132,9 @@ class WordRepository {
     DocumentSnapshot? lastDocument,
     int fetchLimit,
   ) {
-    var query = firestore
-        .collection('Words')
-        .where('initialSubGroupLabel', isEqualTo: initial)
-        .orderBy('reading')
+    var query = _wordsCollectionRef
+        .where(WordsCollection.initialSubGroupLabel, isEqualTo: initial)
+        .orderBy(WordsCollection.reading)
         .limit(fetchLimit);
 
     if (lastDocument != null) {
@@ -145,7 +149,7 @@ class WordRepository {
     DocumentSnapshot? lastDocument,
     int fetchLimit,
   ) {
-    var query = firestore.collection('Words').orderBy('word').startAt(
+    var query = _wordsCollectionRef.orderBy(WordsCollection.word).startAt(
       [searchWord],
     ).endAt(['$searchWord\uf8ff']).limit(fetchLimit);
 
@@ -200,13 +204,12 @@ class WordRepository {
     String currentUserId,
     List<String> mutedUserIdList,
   ) async {
-    final allDefinitionSnapshot = await firestore
-        .collection('Definitions')
-        .where('wordId', isEqualTo: wordId)
+    final allDefinitionSnapshot = await _definitionsCollectionRef
+        .where(DefinitionsCollection.wordId, isEqualTo: wordId)
         .where(
           Filter.or(
-            Filter('authorId', isEqualTo: currentUserId),
-            Filter('isPublic', isEqualTo: true),
+            Filter(DefinitionsCollection.authorId, isEqualTo: currentUserId),
+            Filter(DefinitionsCollection.isPublic, isEqualTo: true),
           ),
         )
         .count()
@@ -239,11 +242,10 @@ class WordRepository {
           i + 10 < mutedUserIdList.length ? i + 10 : mutedUserIdList.length;
       final chunk = mutedUserIdList.sublist(i, end);
 
-      final mutedSnapshot = await firestore
-          .collection('Definitions')
-          .where('wordId', isEqualTo: wordId)
-          .where('authorId', whereIn: chunk)
-          .where('isPublic', isEqualTo: true)
+      final mutedSnapshot = await _definitionsCollectionRef
+          .where(DefinitionsCollection.wordId, isEqualTo: wordId)
+          .where(DefinitionsCollection.authorId, whereIn: chunk)
+          .where(DefinitionsCollection.isPublic, isEqualTo: true)
           .count()
           .get();
 

--- a/lib/feature/word/repository/word_repository.dart
+++ b/lib/feature/word/repository/word_repository.dart
@@ -129,7 +129,7 @@ class WordRepository {
   ) {
     var query = firestore
         .collection('Words')
-        .where('initialLetter', isEqualTo: initial)
+        .where('initialSubGroupLabel', isEqualTo: initial)
         .orderBy('reading')
         .limit(fetchLimit);
 
@@ -186,7 +186,7 @@ class WordRepository {
           id: wordDoc.id,
           word: wordDoc.word,
           reading: wordDoc.reading,
-          initialLetter: wordDoc.initialLetter,
+          initialSubGroupLabel: wordDoc.initialSubGroupLabel,
           postedDefinitionCount: postedDefinitionCount,
         ),
       );

--- a/lib/util/constant/firestore_collections.dart
+++ b/lib/util/constant/firestore_collections.dart
@@ -1,0 +1,71 @@
+// Firestoreのコレクションに対応するclassを定義する
+// createdAt, updatedAtは全コレクション共通のため、classには含めない
+
+const updatedAtFieldName = 'updatedAt';
+const createdAtFieldName = 'createdAt';
+
+class WordsCollection {
+  static const collectionName = 'Words';
+
+  // Field
+  static const word = 'word';
+  static const reading = 'reading';
+  static const initialSubGroupLabel = 'initialSubGroupLabel';
+}
+
+class DefinitionsCollection {
+  static const collectionName = 'Definitions';
+
+  // Field
+  static const wordId = 'wordId';
+  static const word = 'word';
+  static const wordReadingInitialSubGroupLabel =
+      'wordReadingInitialSubGroupLabel';
+  static const authorId = 'authorId';
+  static const definition = 'definition';
+  static const likesCount = 'likesCount';
+  static const isPublic = 'isPublic';
+  // static const isEdited = 'isEdited';
+}
+
+class LikesCollection {
+  static const collectionName = 'Likes';
+
+  // Field
+  static const userId = 'userId';
+  static const definitionId = 'definitionId';
+}
+
+class UserConfigsCollection {
+  static const collectionName = 'UserConfigs';
+
+  // Field
+  static const mutedUserIdList = 'mutedUserIdList';
+  static const osVersion = 'osVersion';
+  static const appVersion = 'appVersion';
+}
+
+class UserFollowsCollection {
+  static const collectionName = 'UserFollows';
+
+  // Field
+  static const followerId = 'followerId';
+  static const followingId = 'followingId';
+}
+
+class UserFollowCountsCollection {
+  static const collectionName = 'UserFollowCounts';
+
+  // Field
+  static const followerCount = 'followerCount';
+  static const followingCount = 'followingCount';
+}
+
+class UserProfilesCollection {
+  static const collectionName = 'UserProfiles';
+
+  // Field
+  static const name = 'name';
+  static const bio = 'bio';
+  static const profileImageUrl = 'profileImageUrl';
+}

--- a/lib/util/constant/initial_main_group.dart
+++ b/lib/util/constant/initial_main_group.dart
@@ -1,3 +1,6 @@
+import '../extension/string_extension.dart';
+import 'string_regex.dart';
+
 enum InitialMainGroup {
   // かな
   japaneseAColumn,
@@ -126,7 +129,8 @@ enum InitialSubGroup {
 
   // その他
   number,
-  symbol;
+  basicSymbol,
+  other;
 
   String get label {
     switch (this) {
@@ -279,9 +283,53 @@ enum InitialSubGroup {
         return 'Z';
       case InitialSubGroup.number:
         return '数字';
-      case InitialSubGroup.symbol:
+      case InitialSubGroup.basicSymbol:
         return '記号';
+      case InitialSubGroup.other:
+        return 'その他';
     }
+  }
+
+  static String labelFromString(String input) {
+    final trimmed = input.trim();
+    if (trimmed.isEmpty) {
+      return InitialSubGroup.other.label;
+    }
+
+    final initial = trimmed.substring(0, 1);
+
+    // ひらがな
+    if (hiraganaRegex.hasMatch(initial)) {
+      return kanaMapping[initial]!.label;
+    }
+
+    // カタカナ
+    if (katakanaRegex.hasMatch(initial)) {
+      final hiraganaInitial = initial.katakanaToHiragana();
+      return kanaMapping[hiraganaInitial]!.label;
+    }
+
+    // アルファベット
+    if (alphabetRegex.hasMatch(initial)) {
+      return InitialSubGroup.values
+          .firstWhere(
+            (element) => element.label == initial.toUpperCase(),
+          )
+          .label;
+    }
+
+    // 数字
+    if (numberRegex.hasMatch(initial)) {
+      return InitialSubGroup.number.label;
+    }
+
+    // 記号
+    if (basicSymbolRegex.hasMatch(initial)) {
+      return InitialSubGroup.basicSymbol.label;
+    }
+
+    // その他
+    return InitialSubGroup.other.label;
   }
 }
 
@@ -382,6 +430,102 @@ final Map<InitialMainGroup, List<InitialSubGroup>> initialMapping = {
   ],
   InitialMainGroup.other: [
     InitialSubGroup.number,
-    InitialSubGroup.symbol,
+    InitialSubGroup.basicSymbol,
+    InitialSubGroup.other,
   ],
+};
+
+final Map<String, InitialSubGroup> kanaMapping = {
+  // 清音 + を + ん
+  'あ': InitialSubGroup.a,
+  'い': InitialSubGroup.i,
+  'う': InitialSubGroup.u,
+  'え': InitialSubGroup.e,
+  'お': InitialSubGroup.o,
+  'か': InitialSubGroup.ka,
+  'き': InitialSubGroup.ki,
+  'く': InitialSubGroup.ku,
+  'け': InitialSubGroup.ke,
+  'こ': InitialSubGroup.ko,
+  'さ': InitialSubGroup.sa,
+  'し': InitialSubGroup.shi,
+  'す': InitialSubGroup.su,
+  'せ': InitialSubGroup.se,
+  'そ': InitialSubGroup.so,
+  'た': InitialSubGroup.ta,
+  'ち': InitialSubGroup.chi,
+  'つ': InitialSubGroup.tsu,
+  'て': InitialSubGroup.te,
+  'と': InitialSubGroup.to,
+  'な': InitialSubGroup.na,
+  'に': InitialSubGroup.ni,
+  'ぬ': InitialSubGroup.nu,
+  'ね': InitialSubGroup.ne,
+  'の': InitialSubGroup.no,
+  'は': InitialSubGroup.ha,
+  'ひ': InitialSubGroup.hi,
+  'ふ': InitialSubGroup.fu,
+  'へ': InitialSubGroup.he,
+  'ほ': InitialSubGroup.ho,
+  'ま': InitialSubGroup.ma,
+  'み': InitialSubGroup.mi,
+  'む': InitialSubGroup.mu,
+  'め': InitialSubGroup.me,
+  'も': InitialSubGroup.mo,
+  'や': InitialSubGroup.ya,
+  'ゆ': InitialSubGroup.yu,
+  'よ': InitialSubGroup.yo,
+  'ら': InitialSubGroup.ra,
+  'り': InitialSubGroup.ri,
+  'る': InitialSubGroup.ru,
+  'れ': InitialSubGroup.re,
+  'ろ': InitialSubGroup.ro,
+  'わ': InitialSubGroup.wa,
+  'を': InitialSubGroup.wo,
+  'ん': InitialSubGroup.n,
+
+  // 濁音
+  'が': InitialSubGroup.ka,
+  'ぎ': InitialSubGroup.ki,
+  'ぐ': InitialSubGroup.ku,
+  'げ': InitialSubGroup.ke,
+  'ご': InitialSubGroup.ko,
+  'ざ': InitialSubGroup.sa,
+  'じ': InitialSubGroup.shi,
+  'ず': InitialSubGroup.su,
+  'ぜ': InitialSubGroup.se,
+  'ぞ': InitialSubGroup.so,
+  'だ': InitialSubGroup.ta,
+  'ぢ': InitialSubGroup.chi,
+  'づ': InitialSubGroup.tsu,
+  'で': InitialSubGroup.te,
+  'ど': InitialSubGroup.to,
+  'ば': InitialSubGroup.ha,
+  'び': InitialSubGroup.hi,
+  'ぶ': InitialSubGroup.fu,
+  'べ': InitialSubGroup.he,
+  'ぼ': InitialSubGroup.ho,
+  'ゔ': InitialSubGroup.u,
+
+  // 半濁音
+  'ぱ': InitialSubGroup.ha,
+  'ぴ': InitialSubGroup.hi,
+  'ぷ': InitialSubGroup.fu,
+  'ぺ': InitialSubGroup.he,
+  'ぽ': InitialSubGroup.ho,
+
+  // 小書き
+  'ぁ': InitialSubGroup.a,
+  'ぃ': InitialSubGroup.i,
+  'ぅ': InitialSubGroup.u,
+  'ぇ': InitialSubGroup.e,
+  'ぉ': InitialSubGroup.o,
+  'ゃ': InitialSubGroup.ya,
+  'ゅ': InitialSubGroup.yu,
+  'ょ': InitialSubGroup.yo,
+  'っ': InitialSubGroup.tsu,
+
+  // 歴史的仮名遣い
+  'ゐ': InitialSubGroup.i,
+  'ゑ': InitialSubGroup.e,
 };

--- a/lib/util/constant/string_regex.dart
+++ b/lib/util/constant/string_regex.dart
@@ -1,0 +1,15 @@
+final hiraganaRegex = RegExp(r'^[ぁ-んゔ]+$');
+final katakanaRegex = RegExp(r'^[ァ-ンヴヷヸヹヺ]+$');
+final alphabetRegex = RegExp(r'^[a-zA-Z]+$');
+final numberRegex = RegExp(r'^[0-9]+$');
+
+/// アプリ内において、「基本的な記号」と定義する記号にマッチする正規表現
+final basicSymbolRegex =
+    RegExp(r'^[!#$%&()*+,\-./:;<=>?@\[\]^_`{|}~（）「」『』ー]+$');
+
+// TODO(me): ベタ書きではなく、既存の定数を使用して定義したい
+
+/// 定義されている全ての正規表現を結合した正規表現
+final combinedRegex = RegExp(
+  r'^[ ぁ-んゔァ-ンヴヷヸヹヺa-zA-Z0-9!#$%&()*+,\-./:;<=>?@\[\\\]^_`{|}~（）「」『』ー]+$',
+);

--- a/lib/util/dummy_data/definitions_dummy.dart
+++ b/lib/util/dummy_data/definitions_dummy.dart
@@ -2,6 +2,8 @@ import 'dart:math';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 
+import '../constant/initial_main_group.dart';
+
 final firestore = FirebaseFirestore.instance;
 final definitionsCollection = firestore.collection('Definitions');
 
@@ -111,15 +113,13 @@ Future<void> addDefinitionDummy0to29(String flavorName) async {
     '限りなく続く未来。',
   ];
 
-  final wordReadingInitialGroups =
-      readings.map(_categorizeFirstCharacter).toList();
-
   for (var i = 0; i < words.length; i++) {
     await Future<void>.delayed(const Duration(microseconds: 300));
     await definitionsCollection.doc('definition${i + 1}').set({
       'wordId': wordIds[i],
       'word': words[i],
-      'wordReadingInitialGroup': wordReadingInitialGroups[i],
+      'wordReadingInitialSubGroupLabel':
+          InitialSubGroup.labelFromString(readings[i]),
       'authorId': 'user${Random().nextInt(20) + 1}',
       'definition': definitions[i],
       'likesCount': Random().nextInt(100),
@@ -128,25 +128,4 @@ Future<void> addDefinitionDummy0to29(String flavorName) async {
       'updatedAt': FieldValue.serverTimestamp(),
     });
   }
-}
-
-String _categorizeFirstCharacter(String text) {
-  final firstChar = text.substring(0, 1);
-
-  if (RegExp(r'^[ぁ-ん]').hasMatch(firstChar)) {
-    return firstChar;
-  } else if (RegExp(r'^[ァ-ヶー]').hasMatch(firstChar)) {
-    return _convertToHiragana(firstChar);
-  } else if (RegExp(r'^[a-zA-Z]').hasMatch(firstChar)) {
-    return firstChar.toUpperCase();
-  } else if (RegExp(r'^[0-9]').hasMatch(firstChar)) {
-    return '数字';
-  } else {
-    return '記号';
-  }
-}
-
-String _convertToHiragana(String katakana) {
-  final offset = 'ァ'.codeUnitAt(0) - 'ぁ'.codeUnitAt(0);
-  return String.fromCharCode(katakana.codeUnitAt(0) - offset);
 }

--- a/lib/util/dummy_data/words_dummy.dart
+++ b/lib/util/dummy_data/words_dummy.dart
@@ -1,6 +1,6 @@
-import 'dart:math';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../constant/initial_main_group.dart';
 
 Future<void> addWordsDummy0to29(String flavorName) async {
   // 語句リスト
@@ -71,41 +71,13 @@ Future<void> addWordsDummy0to29(String flavorName) async {
     'みらいえいごう',
   ];
 
-  // publicDefinitionCountのダミーデータ
-  final publicDefinitionCounts = <int>[
-    5,
-    4,
-    7,
-    6,
-    3,
-    4,
-    5,
-    6,
-    2,
-    7,
-    8,
-    3,
-    4,
-    5,
-    6,
-    7,
-    5,
-    6,
-    7,
-    4,
-    3,
-    6,
-    5,
-    7,
-    3,
-    5,
-    6,
-    7,
-    8,
-    2,
-  ];
-  await _addWordsDummyToFirestore(flavorName, words, readings,
-      publicDefinitionCounts, 0, 29,);
+  await _addWordsDummyToFirestore(
+    flavorName,
+    words,
+    readings,
+    0,
+    29,
+  );
 }
 
 Future<void> addWordsDummy30to59(String flavorName) async {
@@ -177,50 +149,19 @@ Future<void> addWordsDummy30to59(String flavorName) async {
     'ざつおん',
   ];
 
-  // publicDefinitionCountのダミーデータ
-  final publicDefinitionCounts = <int>[
-    6,
-    4,
-    8,
-    7,
-    3,
-    4,
-    5,
-    6,
-    3,
-    7,
-    8,
-    3,
-    4,
-    5,
-    6,
-    7,
-    5,
-    6,
-    7,
-    4,
-    3,
-    6,
-    5,
-    7,
-    3,
-    5,
-    6,
-    7,
-    8,
-    3,
-  ];
-
-  await _addWordsDummyToFirestore(flavorName, words, readings,
-      publicDefinitionCounts, 30, 59,);
+  await _addWordsDummyToFirestore(
+    flavorName,
+    words,
+    readings,
+    30,
+    59,
+  );
 }
-
 
 Future<void> _addWordsDummyToFirestore(
   String flavorName,
   List<String> words,
   List<String> readings,
-  List<int> publicDefinitionCounts,
   int startIndex,
   int endIndex,
 ) async {
@@ -232,36 +173,15 @@ Future<void> _addWordsDummyToFirestore(
   // Words コレクションのテストデータを挿入
   for (var i = 0; i < 30; i++) {
     final wordId = 'word${startIndex + i + 1}';
-    final privateDefinitionCount = Random().nextInt(3);
     final wordData = {
       'id': wordId,
       'word': words[i],
       'reading': readings[i],
-      'initialLetter': readings[i][0], // readingの最初の文字
-      'publicDefinitionCount': publicDefinitionCounts[i],
-      'privateDefinitionCount': privateDefinitionCount,
+      'initialSubGroupLabel': InitialSubGroup.labelFromString(readings[i]),
       'createdAt': FieldValue.serverTimestamp(),
       'updatedAt': FieldValue.serverTimestamp(),
     };
 
     await firestore.collection('Words').doc(wordId).set(wordData);
-
-    // PrivateDefinitionPostedAuthors サブコレクションのテストデータを挿入
-    if (privateDefinitionCount != 0) {
-      final randomIndex = Random().nextInt(19) + 1;
-      final authorData = {
-        'id': 'user$randomIndex',
-        'postedPrivateCount': privateDefinitionCount,
-        'createdAt': FieldValue.serverTimestamp(),
-        'updatedAt': FieldValue.serverTimestamp(),
-      };
-
-      await firestore
-          .collection('Words')
-          .doc(wordId)
-          .collection('PrivateDefinitionPostedAuthors')
-          .doc('user$randomIndex')
-          .set(authorData);
-    }
   }
 }

--- a/lib/util/extension/string_extension.dart
+++ b/lib/util/extension/string_extension.dart
@@ -1,0 +1,34 @@
+extension StringExtension on String {
+  String katakanaToHiragana() {
+    // 1文字のStringであることをチェック
+    if (runes.length != 1) {
+      throw const FormatException('2文字以上の文字列が渡されました。');
+    }
+
+    final code = runes.first;
+    // カタカナかどうかをチェック
+    if (code < 0x30A1 || code > 0x30FA) {
+      throw ArgumentError('カタカナでない文字が渡されました。');
+    }
+
+    // 一般的でないカタカナは直接ひらがなを指定
+    if (this == 'ヷ') {
+      return 'わ';
+    }
+
+    if (this == 'ヸ') {
+      return 'ゐ';
+    }
+
+    if (this == 'ヹ') {
+      return 'ゑ';
+    }
+
+    if (this == 'ヺ') {
+      return 'を';
+    }
+
+    // カタカナからひらがなに変換
+    return String.fromCharCode(code - 0x0060);
+  }
+}

--- a/test/feature/definition/application/definition_id_list_state_test.mocks.dart
+++ b/test/feature/definition/application/definition_id_list_state_test.mocks.dart
@@ -217,7 +217,7 @@ class MockDefinitionRepository extends _i1.Mock
   ) =>
           (super.noSuchMethod(
             Invocation.method(
-              #fetchHomeFollowingDefinitionIdList,
+              #fetchHomeFollowingDefinitionIdListState,
               [
                 currentUserId,
                 targetUserIdList,
@@ -228,7 +228,7 @@ class MockDefinitionRepository extends _i1.Mock
                 _FakeDefinitionIdListState_1(
               this,
               Invocation.method(
-                #fetchHomeFollowingDefinitionIdList,
+                #fetchHomeFollowingDefinitionIdListState,
                 [
                   currentUserId,
                   targetUserIdList,
@@ -241,7 +241,7 @@ class MockDefinitionRepository extends _i1.Mock
                     _FakeDefinitionIdListState_1(
               this,
               Invocation.method(
-                #fetchHomeFollowingDefinitionIdList,
+                #fetchHomeFollowingDefinitionIdListState,
                 [
                   currentUserId,
                   targetUserIdList,

--- a/test/feature/definition/application/definition_service_test.mocks.dart
+++ b/test/feature/definition/application/definition_service_test.mocks.dart
@@ -132,7 +132,7 @@ class MockDefinitionRepository extends _i1.Mock
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchHomeFollowingDefinitionIdList,
+          #fetchHomeFollowingDefinitionIdListState,
           [
             currentUserId,
             targetUserIdList,
@@ -143,7 +143,7 @@ class MockDefinitionRepository extends _i1.Mock
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
-            #fetchHomeFollowingDefinitionIdList,
+            #fetchHomeFollowingDefinitionIdListState,
             [
               currentUserId,
               targetUserIdList,
@@ -155,7 +155,7 @@ class MockDefinitionRepository extends _i1.Mock
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
-            #fetchHomeFollowingDefinitionIdList,
+            #fetchHomeFollowingDefinitionIdListState,
             [
               currentUserId,
               targetUserIdList,

--- a/test/feature/definition/application/definition_state_test.mocks.dart
+++ b/test/feature/definition/application/definition_state_test.mocks.dart
@@ -172,7 +172,7 @@ class MockDefinitionRepository extends _i1.Mock
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchHomeFollowingDefinitionIdList,
+          #fetchHomeFollowingDefinitionIdListState,
           [
             currentUserId,
             targetUserIdList,
@@ -183,7 +183,7 @@ class MockDefinitionRepository extends _i1.Mock
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
-            #fetchHomeFollowingDefinitionIdList,
+            #fetchHomeFollowingDefinitionIdListState,
             [
               currentUserId,
               targetUserIdList,
@@ -195,7 +195,7 @@ class MockDefinitionRepository extends _i1.Mock
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
-            #fetchHomeFollowingDefinitionIdList,
+            #fetchHomeFollowingDefinitionIdListState,
             [
               currentUserId,
               targetUserIdList,

--- a/test/feature/definition/domain/definition_for_write_test.dart
+++ b/test/feature/definition/domain/definition_for_write_test.dart
@@ -332,7 +332,6 @@ void main() {
       // * Assert
       expect(actual, isA<Map<String, dynamic>>());
       expect(actual['word'], word);
-      expect(actual['wordReading'], wordReading);
       expect(actual['wordReadingInitialSubGroupLabel'], 'ほ');
       expect(actual['definition'], definition);
       expect(actual['likesCount'], 0);

--- a/test/feature/definition/domain/definition_for_write_test.dart
+++ b/test/feature/definition/domain/definition_for_write_test.dart
@@ -313,9 +313,9 @@ void main() {
   group('toFirestore()', () {
     test('想定通りにMap型が返されることを検証', () {
       // * Arrange
-      const word = '愛情';
-      const wordReading = 'あいじょう';
-      const definition = '他者を思いやる深い感情。';
+      const word = '冒険';
+      const wordReading = 'ぼうけん';
+      const definition = 'かかんに挑むこと';
       const isPublic = true;
 
       const definitionForWrite = DefinitionForWrite(
@@ -333,90 +333,10 @@ void main() {
       expect(actual, isA<Map<String, dynamic>>());
       expect(actual['word'], word);
       expect(actual['wordReading'], wordReading);
-      expect(actual['wordReadingInitialGroup'], 'あ');
+      expect(actual['wordReadingInitialSubGroupLabel'], 'ほ');
       expect(actual['definition'], definition);
       expect(actual['likesCount'], 0);
       expect(actual['isPublic'], isPublic);
-    });
-  });
-
-  group('_categorizeFirstCharacter()', () {
-    test('全てのひらがな', () {
-      // * Arrange
-      // ひらがなの全範囲
-      var allHiragana = 'あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん';
-      // 濁点と半濁点を含む文字も追加
-      allHiragana += 'がぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽ';
-
-      for (final char in allHiragana.split('')) {
-        // * Act
-        final actual = baseDefinitionForWrite.categorizeFirstCharacter(char);
-
-        // * Assert
-        expect(actual, char);
-      }
-    });
-
-    test('全てのカタカナ', () {
-      // * Arrange
-      var allKatakana = 'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン';
-      // 濁点と半濁点を含む文字も追加
-      allKatakana += 'ガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポ';
-      // 予め変換されたひらがなを用意
-      var allHiragana = 'あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん';
-      // 濁点と半濁点を含む文字も追加
-      allHiragana += 'がぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽ';
-
-      final katakanaArray = allKatakana.split('');
-      final hiraganaArray = allHiragana.split('');
-
-      for (var i = 0; i < katakanaArray.length; i++) {
-        // * Act
-        final actual =
-            baseDefinitionForWrite.categorizeFirstCharacter(katakanaArray[i]);
-
-        // * Assert
-        expect(actual, hiraganaArray[i]);
-      }
-    });
-
-    test('全ての大文字アルファベット', () {
-      // * Arrange
-      const allUppercaseAlphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-
-      for (final char in allUppercaseAlphabet.split('')) {
-        // * Act
-        final actual = baseDefinitionForWrite.categorizeFirstCharacter(char);
-
-        // * Assert
-        expect(actual, char);
-      }
-    });
-
-    test('全ての小文字アルファベット', () {
-      // * Arrange
-      const allLowercaseAlphabet = 'abcdefghijklmnopqrstuvwxyz';
-
-      for (final char in allLowercaseAlphabet.split('')) {
-        // * Act
-        final actual = baseDefinitionForWrite.categorizeFirstCharacter(char);
-
-        // * Assert
-        expect(actual, char.toUpperCase());
-      }
-    });
-
-    test('全ての数字', () {
-      // * Arrange
-      const allDigits = '0123456789';
-
-      for (final char in allDigits.split('')) {
-        // * Act
-        final actual = baseDefinitionForWrite.categorizeFirstCharacter(char);
-
-        // * Assert
-        expect(actual, '数字');
-      }
     });
   });
 }

--- a/test/mock/mock_data.dart
+++ b/test/mock/mock_data.dart
@@ -70,7 +70,7 @@ final mockWordDoc = WordDocument(
   id: 'wordId',
   word: 'word',
   reading: 'reading',
-  initialLetter: 'i',
+  initialSubGroupLabel: 'R',
   createdAt: nowDateTime,
   updatedAt: nowDateTime,
 );

--- a/test/util/constant/initial_main_group_test.dart
+++ b/test/util/constant/initial_main_group_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:teigi_app/util/constant/initial_main_group.dart';
+
+void main() {
+  group('labelFromString()', () {
+    test('全てのひらがな', () {
+      // * Arrange
+      var allHiragana =
+          'あいうえお かきくけこ さしすせそ たちつてと なにぬねの はひふへほ まみむめも やゆよ らりるれろ わをん';
+      // 濁音、半濁音
+      allHiragana += 'がぎぐげご ざじずぜぞ だぢづでど ばびぶべぼ ぱぴぷぺぽ';
+      // 小書き, ヴ
+      allHiragana += 'ぁぃぅぇぉ っ ゃゅょ ゔ';
+      // 特殊
+      allHiragana += 'わゐゑを';
+
+      var allExpected =
+          'あいうえお かきくけこ さしすせそ たちつてと なにぬねの はひふへほ まみむめも やゆよ らりるれろ わをん';
+      // 濁音、半濁音（清音になる）
+      allExpected += 'かきくけこ さしすせそ たちつてと はひふへほ はひふへほ';
+      // 小書き, ヴ（清音になる）
+      allExpected += 'あいうえお つ やゆよ う';
+      // 特殊（清音になる）
+      allExpected += 'わいえを';
+
+      final hiraganaList = allHiragana.replaceAll(RegExp(r'\s+'), '').split('');
+      final expectedList = allExpected.replaceAll(RegExp(r'\s+'), '').split('');
+
+      for (var i = 0; i < hiraganaList.length; i++) {
+        // * Act
+        final actual = InitialSubGroup.labelFromString(hiraganaList[i]);
+
+        // * Assert
+        final expected = expectedList[i];
+        expect(actual, expected);
+      }
+    });
+
+    test('全てのカタカナ', () {
+      // * Arrange
+      var allKatakana =
+          'アイウエオ カキクケコ サシスセソ タチツテト ナニヌネノ ハヒフヘホ マミムメモ ヤユヨ ラリルレロ ワヲン';
+      // 濁音、半濁音
+      allKatakana += 'ガギグゲゴ ザジズゼゾ ダヂヅデド バビブベボ パピプペポ';
+      // 小書き, ヴ
+      allKatakana += 'ァィゥェォ ッ ャュョ ヴ';
+      // 特殊
+      allKatakana += 'ヷヸヹヺ';
+
+      var allExpected =
+          'あいうえお かきくけこ さしすせそ たちつてと なにぬねの はひふへほ まみむめも やゆよ らりるれろ わをん';
+      // 濁音、半濁音（清音になる）
+      allExpected += 'かきくけこ さしすせそ たちつてと はひふへほ はひふへほ';
+      // 小書き, ヴ（清音になる）
+      allExpected += 'あいうえお つ やゆよ う';
+      // 特殊（清音になる）
+      allExpected += 'わいえを';
+
+      final katakanaList = allKatakana.replaceAll(RegExp(r'\s+'), '').split('');
+      final expectedList = allExpected.replaceAll(RegExp(r'\s+'), '').split('');
+
+      for (var i = 0; i < katakanaList.length; i++) {
+        // * Act
+        final actual = InitialSubGroup.labelFromString(katakanaList[i]);
+
+        // * Assert
+        final expected = expectedList[i];
+        expect(actual, expected);
+      }
+    });
+
+    test('全てのアルファベット', () {
+      // * Arrange
+      var allAlphabet = 'abcdefghijklmnopqrstuvwxyz';
+      allAlphabet += 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+      var allExpected = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+      allExpected += 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+      final alphabetList = allAlphabet.split('');
+      final expectedList = allExpected.split('');
+
+      for (var i = 0; i < alphabetList.length; i++) {
+        // * Act
+        final actual = InitialSubGroup.labelFromString(alphabetList[i]);
+
+        // * Assert
+        final expected = expectedList[i];
+        expect(actual, expected);
+      }
+    });
+
+    test('全ての数字', () {
+      // * Arrange
+      const allNumber = '0123456789';
+      final numberList = allNumber.split('');
+
+      for (var i = 0; i < numberList.length; i++) {
+        // * Act
+        final actual = InitialSubGroup.labelFromString(numberList[i]);
+
+        // * Assert
+        expect(actual, InitialSubGroup.number.label);
+      }
+    });
+
+    test('[basicSymbolRegex]にマッチする記号', () {
+      // * Arrange
+      const allSymbol = '!#\$%&()*+,-./:;<=>?@[]^_`{|}~（）「」『』ー';
+      final symbolList = allSymbol.split('');
+
+      for (var i = 0; i < symbolList.length; i++) {
+        // * Act
+        final actual = InitialSubGroup.labelFromString(symbolList[i]);
+
+        // * Assert
+        expect(actual, InitialSubGroup.basicSymbol.label);
+      }
+    });
+
+    test('その他', () {
+      // * Arrange
+      const allOther = ' ｡｢｣､･ｰ２Ａｱ😆';
+      final otherList = allOther.split('');
+
+      for (var i = 0; i < otherList.length; i++) {
+        // * Act
+        final actual = InitialSubGroup.labelFromString(otherList[i]);
+
+        // * Assert
+        expect(actual, InitialSubGroup.other.label);
+      }
+    });
+
+    test('2文字', () {
+      // * Arrange & Act
+      final actual = InitialSubGroup.labelFromString('とり');
+
+      // * Assert
+      expect(actual, InitialSubGroup.to.label);
+    });
+
+    test('空文字', () {
+      // * Arrange & Act
+      final actual = InitialSubGroup.labelFromString('');
+
+      // * Assert
+      expect(actual, InitialSubGroup.other.label);
+    });
+  });
+}

--- a/test/util/extension/string_extension_test.dart
+++ b/test/util/extension/string_extension_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:teigi_app/util/extension/string_extension.dart';
+
+void main() {
+  group('katakanaToHiragana()', () {
+    test('全てのカタカナ', () {
+      // * Arrange
+      var allKatakana = 'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン';
+      // 濁音、半濁音
+      allKatakana += 'ガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポ';
+      // 小書き, ヴ
+      allKatakana += 'ァィゥェォッャュョヴ';
+      // 特殊
+      allKatakana += 'ヷヸヹヺ';
+
+      var allHiragana = 'あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん';
+      allHiragana += 'がぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽ';
+      allHiragana += 'ぁぃぅぇぉっゃゅょゔ';
+      allHiragana += 'わゐゑを';
+
+      final katakanaArray = allKatakana.split('');
+      final hiraganaArray = allHiragana.split('');
+
+      for (var i = 0; i < katakanaArray.length; i++) {
+        // * Act
+        final actual = katakanaArray[i].katakanaToHiragana();
+
+        // * Assert
+        final expected = hiraganaArray[i];
+        expect(actual, expected);
+      }
+    });
+
+    test('2文字以上', () {
+      // * Arrange
+      const hiragana = 'サケ';
+
+      // * Act & Assert
+      expect(
+        () => hiragana.katakanaToHiragana(),
+        throwsFormatException,
+      );
+    });
+
+    test('空文字', () {
+      // * Arrange
+      const hiragana = '';
+
+      // * Act & Assert
+      expect(
+        () => hiragana.katakanaToHiragana(),
+        throwsFormatException,
+      );
+    });
+
+    test('スペース', () {
+      // * Arrange
+      const hiragana = ' ';
+
+      // * Act & Assert
+      expect(
+        () => hiragana.katakanaToHiragana(),
+        throwsArgumentError,
+      );
+    });
+
+    test('ひらがな', () {
+      // * Arrange
+      const hiragana = 'あ';
+
+      // * Act & Assert
+      expect(
+        () => hiragana.katakanaToHiragana(),
+        throwsArgumentError,
+      );
+    });
+
+    test('数字', () {
+      // * Arrange
+      const hiragana = '1';
+
+      // * Act & Assert
+      expect(
+        () => hiragana.katakanaToHiragana(),
+        throwsArgumentError,
+      );
+    });
+
+    test('半角カタカナ', () {
+      // * Arrange
+      const hiragana = 'ｱ';
+
+      // * Act & Assert
+      expect(
+        () => hiragana.katakanaToHiragana(),
+        throwsArgumentError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# 対象Issue

- #65 

# やった事

- initialLetterを出力するロジックを修正
- Firestoreのコレクション名、フィールド名を専用ファイルで管理するようリファクタ

# やらなかった事

# 動作確認

- iPhone11 (実機) で実施

# その他

