### PR TITLE
定義周りのUIを更新

### DIFF
--- a/lib/feature/definition/application/definition_state.dart
+++ b/lib/feature/definition/application/definition_state.dart
@@ -39,9 +39,7 @@ Future<Definition> definition(DefinitionRef ref, String definitionId) async {
     definition: definitionDoc.definition,
     likesCount: definitionDoc.likesCount,
     isPublic: definitionDoc.isPublic,
-    isEdited: definitionDoc.isEdited,
     isLikedByUser: isLikedByUser,
     createdAt: definitionDoc.createdAt,
-    updatedAt: definitionDoc.updatedAt,
   );
 }

--- a/lib/feature/definition/application/definition_state.dart
+++ b/lib/feature/definition/application/definition_state.dart
@@ -39,6 +39,7 @@ Future<Definition> definition(DefinitionRef ref, String definitionId) async {
     definition: definitionDoc.definition,
     likesCount: definitionDoc.likesCount,
     isPublic: definitionDoc.isPublic,
+    isEdited: definitionDoc.isEdited,
     isLikedByUser: isLikedByUser,
     createdAt: definitionDoc.createdAt,
     updatedAt: definitionDoc.updatedAt,

--- a/lib/feature/definition/application/definition_state.g.dart
+++ b/lib/feature/definition/application/definition_state.g.dart
@@ -6,7 +6,7 @@ part of 'definition_state.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$definitionHash() => r'feda548e7fa741d302ea7dfce2a7272816812c7f';
+String _$definitionHash() => r'bc272c27067ab2006dee9d8da745423adc7fd59f';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/feature/definition/domain/definition.dart
+++ b/lib/feature/definition/domain/definition.dart
@@ -16,6 +16,7 @@ class Definition with _$Definition {
     required String authorImageUrl,
     required String definition,
     required bool isPublic,
+    required bool isEdited,
     required int likesCount,
     required bool isLikedByUser,
     required DateTime createdAt,

--- a/lib/feature/definition/domain/definition.dart
+++ b/lib/feature/definition/domain/definition.dart
@@ -16,11 +16,9 @@ class Definition with _$Definition {
     required String authorImageUrl,
     required String definition,
     required bool isPublic,
-    required bool isEdited,
     required int likesCount,
     required bool isLikedByUser,
     required DateTime createdAt,
-    required DateTime updatedAt,
   }) = _Definition;
   const Definition._();
 

--- a/lib/feature/definition/domain/definition.freezed.dart
+++ b/lib/feature/definition/domain/definition.freezed.dart
@@ -25,6 +25,7 @@ mixin _$Definition {
   String get authorImageUrl => throw _privateConstructorUsedError;
   String get definition => throw _privateConstructorUsedError;
   bool get isPublic => throw _privateConstructorUsedError;
+  bool get isEdited => throw _privateConstructorUsedError;
   int get likesCount => throw _privateConstructorUsedError;
   bool get isLikedByUser => throw _privateConstructorUsedError;
   DateTime get createdAt => throw _privateConstructorUsedError;
@@ -51,6 +52,7 @@ abstract class $DefinitionCopyWith<$Res> {
       String authorImageUrl,
       String definition,
       bool isPublic,
+      bool isEdited,
       int likesCount,
       bool isLikedByUser,
       DateTime createdAt,
@@ -79,6 +81,7 @@ class _$DefinitionCopyWithImpl<$Res, $Val extends Definition>
     Object? authorImageUrl = null,
     Object? definition = null,
     Object? isPublic = null,
+    Object? isEdited = null,
     Object? likesCount = null,
     Object? isLikedByUser = null,
     Object? createdAt = null,
@@ -121,6 +124,10 @@ class _$DefinitionCopyWithImpl<$Res, $Val extends Definition>
           ? _value.isPublic
           : isPublic // ignore: cast_nullable_to_non_nullable
               as bool,
+      isEdited: null == isEdited
+          ? _value.isEdited
+          : isEdited // ignore: cast_nullable_to_non_nullable
+              as bool,
       likesCount: null == likesCount
           ? _value.likesCount
           : likesCount // ignore: cast_nullable_to_non_nullable
@@ -159,6 +166,7 @@ abstract class _$$_DefinitionCopyWith<$Res>
       String authorImageUrl,
       String definition,
       bool isPublic,
+      bool isEdited,
       int likesCount,
       bool isLikedByUser,
       DateTime createdAt,
@@ -185,6 +193,7 @@ class __$$_DefinitionCopyWithImpl<$Res>
     Object? authorImageUrl = null,
     Object? definition = null,
     Object? isPublic = null,
+    Object? isEdited = null,
     Object? likesCount = null,
     Object? isLikedByUser = null,
     Object? createdAt = null,
@@ -227,6 +236,10 @@ class __$$_DefinitionCopyWithImpl<$Res>
           ? _value.isPublic
           : isPublic // ignore: cast_nullable_to_non_nullable
               as bool,
+      isEdited: null == isEdited
+          ? _value.isEdited
+          : isEdited // ignore: cast_nullable_to_non_nullable
+              as bool,
       likesCount: null == likesCount
           ? _value.likesCount
           : likesCount // ignore: cast_nullable_to_non_nullable
@@ -260,6 +273,7 @@ class _$_Definition extends _Definition {
       required this.authorImageUrl,
       required this.definition,
       required this.isPublic,
+      required this.isEdited,
       required this.likesCount,
       required this.isLikedByUser,
       required this.createdAt,
@@ -285,6 +299,8 @@ class _$_Definition extends _Definition {
   @override
   final bool isPublic;
   @override
+  final bool isEdited;
+  @override
   final int likesCount;
   @override
   final bool isLikedByUser;
@@ -295,7 +311,7 @@ class _$_Definition extends _Definition {
 
   @override
   String toString() {
-    return 'Definition(id: $id, wordId: $wordId, word: $word, wordReading: $wordReading, authorId: $authorId, authorName: $authorName, authorImageUrl: $authorImageUrl, definition: $definition, isPublic: $isPublic, likesCount: $likesCount, isLikedByUser: $isLikedByUser, createdAt: $createdAt, updatedAt: $updatedAt)';
+    return 'Definition(id: $id, wordId: $wordId, word: $word, wordReading: $wordReading, authorId: $authorId, authorName: $authorName, authorImageUrl: $authorImageUrl, definition: $definition, isPublic: $isPublic, isEdited: $isEdited, likesCount: $likesCount, isLikedByUser: $isLikedByUser, createdAt: $createdAt, updatedAt: $updatedAt)';
   }
 
   @override
@@ -318,6 +334,8 @@ class _$_Definition extends _Definition {
                 other.definition == definition) &&
             (identical(other.isPublic, isPublic) ||
                 other.isPublic == isPublic) &&
+            (identical(other.isEdited, isEdited) ||
+                other.isEdited == isEdited) &&
             (identical(other.likesCount, likesCount) ||
                 other.likesCount == likesCount) &&
             (identical(other.isLikedByUser, isLikedByUser) ||
@@ -340,6 +358,7 @@ class _$_Definition extends _Definition {
       authorImageUrl,
       definition,
       isPublic,
+      isEdited,
       likesCount,
       isLikedByUser,
       createdAt,
@@ -363,6 +382,7 @@ abstract class _Definition extends Definition {
       required final String authorImageUrl,
       required final String definition,
       required final bool isPublic,
+      required final bool isEdited,
       required final int likesCount,
       required final bool isLikedByUser,
       required final DateTime createdAt,
@@ -387,6 +407,8 @@ abstract class _Definition extends Definition {
   String get definition;
   @override
   bool get isPublic;
+  @override
+  bool get isEdited;
   @override
   int get likesCount;
   @override

--- a/lib/feature/definition/domain/definition.freezed.dart
+++ b/lib/feature/definition/domain/definition.freezed.dart
@@ -25,11 +25,9 @@ mixin _$Definition {
   String get authorImageUrl => throw _privateConstructorUsedError;
   String get definition => throw _privateConstructorUsedError;
   bool get isPublic => throw _privateConstructorUsedError;
-  bool get isEdited => throw _privateConstructorUsedError;
   int get likesCount => throw _privateConstructorUsedError;
   bool get isLikedByUser => throw _privateConstructorUsedError;
   DateTime get createdAt => throw _privateConstructorUsedError;
-  DateTime get updatedAt => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $DefinitionCopyWith<Definition> get copyWith =>
@@ -52,11 +50,9 @@ abstract class $DefinitionCopyWith<$Res> {
       String authorImageUrl,
       String definition,
       bool isPublic,
-      bool isEdited,
       int likesCount,
       bool isLikedByUser,
-      DateTime createdAt,
-      DateTime updatedAt});
+      DateTime createdAt});
 }
 
 /// @nodoc
@@ -81,11 +77,9 @@ class _$DefinitionCopyWithImpl<$Res, $Val extends Definition>
     Object? authorImageUrl = null,
     Object? definition = null,
     Object? isPublic = null,
-    Object? isEdited = null,
     Object? likesCount = null,
     Object? isLikedByUser = null,
     Object? createdAt = null,
-    Object? updatedAt = null,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -124,10 +118,6 @@ class _$DefinitionCopyWithImpl<$Res, $Val extends Definition>
           ? _value.isPublic
           : isPublic // ignore: cast_nullable_to_non_nullable
               as bool,
-      isEdited: null == isEdited
-          ? _value.isEdited
-          : isEdited // ignore: cast_nullable_to_non_nullable
-              as bool,
       likesCount: null == likesCount
           ? _value.likesCount
           : likesCount // ignore: cast_nullable_to_non_nullable
@@ -139,10 +129,6 @@ class _$DefinitionCopyWithImpl<$Res, $Val extends Definition>
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _value.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
               as DateTime,
     ) as $Val);
   }
@@ -166,11 +152,9 @@ abstract class _$$_DefinitionCopyWith<$Res>
       String authorImageUrl,
       String definition,
       bool isPublic,
-      bool isEdited,
       int likesCount,
       bool isLikedByUser,
-      DateTime createdAt,
-      DateTime updatedAt});
+      DateTime createdAt});
 }
 
 /// @nodoc
@@ -193,11 +177,9 @@ class __$$_DefinitionCopyWithImpl<$Res>
     Object? authorImageUrl = null,
     Object? definition = null,
     Object? isPublic = null,
-    Object? isEdited = null,
     Object? likesCount = null,
     Object? isLikedByUser = null,
     Object? createdAt = null,
-    Object? updatedAt = null,
   }) {
     return _then(_$_Definition(
       id: null == id
@@ -236,10 +218,6 @@ class __$$_DefinitionCopyWithImpl<$Res>
           ? _value.isPublic
           : isPublic // ignore: cast_nullable_to_non_nullable
               as bool,
-      isEdited: null == isEdited
-          ? _value.isEdited
-          : isEdited // ignore: cast_nullable_to_non_nullable
-              as bool,
       likesCount: null == likesCount
           ? _value.likesCount
           : likesCount // ignore: cast_nullable_to_non_nullable
@@ -251,10 +229,6 @@ class __$$_DefinitionCopyWithImpl<$Res>
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _value.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
               as DateTime,
     ));
   }
@@ -273,11 +247,9 @@ class _$_Definition extends _Definition {
       required this.authorImageUrl,
       required this.definition,
       required this.isPublic,
-      required this.isEdited,
       required this.likesCount,
       required this.isLikedByUser,
-      required this.createdAt,
-      required this.updatedAt})
+      required this.createdAt})
       : super._();
 
   @override
@@ -299,19 +271,15 @@ class _$_Definition extends _Definition {
   @override
   final bool isPublic;
   @override
-  final bool isEdited;
-  @override
   final int likesCount;
   @override
   final bool isLikedByUser;
   @override
   final DateTime createdAt;
-  @override
-  final DateTime updatedAt;
 
   @override
   String toString() {
-    return 'Definition(id: $id, wordId: $wordId, word: $word, wordReading: $wordReading, authorId: $authorId, authorName: $authorName, authorImageUrl: $authorImageUrl, definition: $definition, isPublic: $isPublic, isEdited: $isEdited, likesCount: $likesCount, isLikedByUser: $isLikedByUser, createdAt: $createdAt, updatedAt: $updatedAt)';
+    return 'Definition(id: $id, wordId: $wordId, word: $word, wordReading: $wordReading, authorId: $authorId, authorName: $authorName, authorImageUrl: $authorImageUrl, definition: $definition, isPublic: $isPublic, likesCount: $likesCount, isLikedByUser: $isLikedByUser, createdAt: $createdAt)';
   }
 
   @override
@@ -334,16 +302,12 @@ class _$_Definition extends _Definition {
                 other.definition == definition) &&
             (identical(other.isPublic, isPublic) ||
                 other.isPublic == isPublic) &&
-            (identical(other.isEdited, isEdited) ||
-                other.isEdited == isEdited) &&
             (identical(other.likesCount, likesCount) ||
                 other.likesCount == likesCount) &&
             (identical(other.isLikedByUser, isLikedByUser) ||
                 other.isLikedByUser == isLikedByUser) &&
             (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt));
+                other.createdAt == createdAt));
   }
 
   @override
@@ -358,11 +322,9 @@ class _$_Definition extends _Definition {
       authorImageUrl,
       definition,
       isPublic,
-      isEdited,
       likesCount,
       isLikedByUser,
-      createdAt,
-      updatedAt);
+      createdAt);
 
   @JsonKey(ignore: true)
   @override
@@ -382,11 +344,9 @@ abstract class _Definition extends Definition {
       required final String authorImageUrl,
       required final String definition,
       required final bool isPublic,
-      required final bool isEdited,
       required final int likesCount,
       required final bool isLikedByUser,
-      required final DateTime createdAt,
-      required final DateTime updatedAt}) = _$_Definition;
+      required final DateTime createdAt}) = _$_Definition;
   const _Definition._() : super._();
 
   @override
@@ -408,15 +368,11 @@ abstract class _Definition extends Definition {
   @override
   bool get isPublic;
   @override
-  bool get isEdited;
-  @override
   int get likesCount;
   @override
   bool get isLikedByUser;
   @override
   DateTime get createdAt;
-  @override
-  DateTime get updatedAt;
   @override
   @JsonKey(ignore: true)
   _$$_DefinitionCopyWith<_$_Definition> get copyWith =>

--- a/lib/feature/definition/domain/definition_for_write.dart
+++ b/lib/feature/definition/domain/definition_for_write.dart
@@ -93,6 +93,7 @@ class DefinitionForWrite with _$DefinitionForWrite {
       DefinitionsCollection.definition: definition,
       DefinitionsCollection.likesCount: 0,
       DefinitionsCollection.isPublic: isPublic,
+      DefinitionsCollection.isEdited: false,
     };
   }
 
@@ -103,6 +104,7 @@ class DefinitionForWrite with _$DefinitionForWrite {
           _wordReadingInitialLabel,
       DefinitionsCollection.definition: definition,
       DefinitionsCollection.isPublic: isPublic,
+      DefinitionsCollection.isEdited: true,
     };
   }
 

--- a/lib/feature/definition/presentation/component/definition_tile.dart
+++ b/lib/feature/definition/presentation/component/definition_tile.dart
@@ -70,6 +70,20 @@ class DefinitionTile extends ConsumerWidget {
                                 ),
                               ),
                               const SizedBox(width: 4),
+                              definition.isEdited
+                                  ? Row(
+                                      children: [
+                                        Icon(
+                                          CupertinoIcons.pencil,
+                                          size: 16,
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .onSurfaceVariant,
+                                        ),
+                                        const SizedBox(width: 4),
+                                      ],
+                                    )
+                                  : const SizedBox.shrink(),
                               definition.isPublic
                                   ? const SizedBox.shrink()
                                   : Row(

--- a/lib/feature/definition/presentation/component/definition_tile.dart
+++ b/lib/feature/definition/presentation/component/definition_tile.dart
@@ -116,7 +116,10 @@ class DefinitionTile extends ConsumerWidget {
                             maxLines: 5,
                           ),
                           const SizedBox(height: 8),
-                          LikeWidget(definition: definition),
+                          Align(
+                            alignment: Alignment.centerLeft,
+                            child: LikeWidget(definition: definition),
+                          ),
                         ],
                       ),
                     ),

--- a/lib/feature/definition/presentation/component/definition_tile.dart
+++ b/lib/feature/definition/presentation/component/definition_tile.dart
@@ -1,4 +1,5 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -59,6 +60,7 @@ class DefinitionTile extends ConsumerWidget {
                         children: [
                           Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Expanded(
                                 child: Text(
@@ -68,6 +70,20 @@ class DefinitionTile extends ConsumerWidget {
                                 ),
                               ),
                               const SizedBox(width: 4),
+                              definition.isPublic
+                                  ? const SizedBox.shrink()
+                                  : Row(
+                                      children: [
+                                        Icon(
+                                          CupertinoIcons.lock_fill,
+                                          size: 16,
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .onSurfaceVariant,
+                                        ),
+                                        const SizedBox(width: 4),
+                                      ],
+                                    ),
                               Text(
                                 definition.updatedAt.timeAgo(DateTime.now()),
                               ),

--- a/lib/feature/definition/presentation/component/definition_tile.dart
+++ b/lib/feature/definition/presentation/component/definition_tile.dart
@@ -5,7 +5,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/common_widget/adaptive_overflow_text.dart';
 import '../../../../core/router/app_router.dart';
-import '../../../../util/extension/date_time_extension.dart';
 import '../../../../util/logger.dart';
 import '../../application/definition_state.dart';
 import 'avatar_icon_widget.dart';
@@ -70,20 +69,6 @@ class DefinitionTile extends ConsumerWidget {
                                 ),
                               ),
                               const SizedBox(width: 4),
-                              definition.isEdited
-                                  ? Row(
-                                      children: [
-                                        Icon(
-                                          CupertinoIcons.pencil,
-                                          size: 16,
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .onSurfaceVariant,
-                                        ),
-                                        const SizedBox(width: 4),
-                                      ],
-                                    )
-                                  : const SizedBox.shrink(),
                               definition.isPublic
                                   ? const SizedBox.shrink()
                                   : Row(
@@ -98,9 +83,6 @@ class DefinitionTile extends ConsumerWidget {
                                         const SizedBox(width: 4),
                                       ],
                                     ),
-                              Text(
-                                definition.updatedAt.timeAgo(DateTime.now()),
-                              ),
                             ],
                           ),
                           Text(

--- a/lib/feature/definition/presentation/component/like_widget.dart
+++ b/lib/feature/definition/presentation/component/like_widget.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:like_button/like_button.dart';
@@ -28,7 +29,7 @@ class LikeWidget extends ConsumerWidget {
           ),
           likeBuilder: (bool isLiked) {
             return Icon(
-              isLiked ? Icons.favorite : Icons.favorite_outline,
+              isLiked ? CupertinoIcons.heart_fill : CupertinoIcons.heart,
               color:
                   isLiked ? likeColor : Theme.of(context).colorScheme.outline,
               size: 20,

--- a/lib/feature/definition/presentation/component/like_widget.dart
+++ b/lib/feature/definition/presentation/component/like_widget.dart
@@ -7,6 +7,7 @@ import '../../../../util/constant/color_scheme.dart';
 import '../../application/definition_service.dart';
 import '../../domain/definition.dart';
 
+// TODO(me): UIの左に余白があるのでそれをなくす
 class LikeWidget extends ConsumerWidget {
   const LikeWidget({
     super.key,

--- a/lib/feature/definition/presentation/page/definition_detail/definition_detail_page.dart
+++ b/lib/feature/definition/presentation/page/definition_detail/definition_detail_page.dart
@@ -63,46 +63,33 @@ class DefinitionDetailPage extends ConsumerWidget {
                         : Center(
                             child: Column(
                               children: [
-                                DecoratedBox(
-                                  decoration: BoxDecoration(
-                                    color: Theme.of(context)
-                                        .colorScheme
-                                        .surfaceVariant
-                                        .withOpacity(0.5),
-                                    borderRadius: BorderRadius.circular(8),
-                                  ),
-                                  child: Padding(
-                                    padding: const EdgeInsets.all(8),
-                                    child: Row(
-                                      mainAxisSize: MainAxisSize.min,
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.start,
-                                      children: [
-                                        Icon(
-                                          CupertinoIcons.lock_fill,
-                                          size: 16,
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .onSurfaceVariant,
-                                        ),
-                                        const SizedBox(width: 2),
-                                        Text(
-                                          'この投稿はあなただけに見えています',
-                                          style: Theme.of(context)
-                                              .textTheme
-                                              .bodyMedium!
-                                              .copyWith(
-                                                color: Theme.of(context)
-                                                    .colorScheme
-                                                    .onSurfaceVariant,
-                                                fontWeight: FontWeight.bold,
-                                              ),
-                                        ),
-                                      ],
+                                Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Icon(
+                                      CupertinoIcons.lock_fill,
+                                      size: 16,
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .onSurfaceVariant,
                                     ),
-                                  ),
+                                    const SizedBox(width: 2),
+                                    Text(
+                                      'この投稿はあなただけに見えています',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .bodyMedium!
+                                          .copyWith(
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .onSurfaceVariant,
+                                            fontWeight: FontWeight.bold,
+                                          ),
+                                    ),
+                                  ],
                                 ),
-                                const SizedBox(height: 8),
+                                const SizedBox(height: 16),
                               ],
                             ),
                           ),
@@ -146,7 +133,15 @@ class DefinitionDetailPage extends ConsumerWidget {
                           ),
                           Text(
                             definition.wordReading,
-                            style: Theme.of(context).textTheme.titleSmall,
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleSmall!
+                                .copyWith(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurfaceVariant,
+                                  fontWeight: FontWeight.bold,
+                                ),
                           ),
                         ],
                       ),
@@ -154,12 +149,9 @@ class DefinitionDetailPage extends ConsumerWidget {
                     const SizedBox(height: 16),
                     Text(
                       definition.definition,
-                      // TODO(me): 用途的に、bodyLargeのサイズを大きくして使う方がよさげ
-                      style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                            fontWeight: FontWeight.normal,
-                          ),
+                      style: Theme.of(context).textTheme.bodyLarge,
                     ),
-                    const SizedBox(height: 16),
+                    const SizedBox(height: 48),
                     Row(
                       children: [
                         Text(
@@ -168,12 +160,13 @@ class DefinitionDetailPage extends ConsumerWidget {
                         ),
                         const SizedBox(width: 2),
                         Text(
-                          '作成',
+                          '投稿',
                           style: Theme.of(context).textTheme.bodyMedium,
                         ),
                       ],
                     ),
                     Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
                           definition.updatedAt.toDisplayFormat(),
@@ -184,6 +177,31 @@ class DefinitionDetailPage extends ConsumerWidget {
                           '更新',
                           style: Theme.of(context).textTheme.bodyMedium,
                         ),
+                        definition.isEdited
+                            ? Row(
+                                children: [
+                                  const SizedBox(width: 8),
+                                  Text(
+                                    '編集済み',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .bodyMedium!
+                                        .copyWith(
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .onSurfaceVariant,
+                                        ),
+                                  ),
+                                  Icon(
+                                    CupertinoIcons.pencil,
+                                    size: 16,
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onSurfaceVariant,
+                                  ),
+                                ],
+                              )
+                            : const SizedBox.shrink(),
                       ],
                     ),
                     const SizedBox(height: 8),

--- a/lib/feature/definition/presentation/page/definition_detail/definition_detail_page.dart
+++ b/lib/feature/definition/presentation/page/definition_detail/definition_detail_page.dart
@@ -1,5 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_refresh/easy_refresh.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -57,6 +58,54 @@ class DefinitionDetailPage extends ConsumerWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
+                    definition.isPublic
+                        ? const SizedBox.shrink()
+                        : Center(
+                            child: Column(
+                              children: [
+                                DecoratedBox(
+                                  decoration: BoxDecoration(
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .surfaceVariant
+                                        .withOpacity(0.5),
+                                    borderRadius: BorderRadius.circular(8),
+                                  ),
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(8),
+                                    child: Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        Icon(
+                                          CupertinoIcons.lock_fill,
+                                          size: 16,
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .onSurfaceVariant,
+                                        ),
+                                        const SizedBox(width: 2),
+                                        Text(
+                                          'この投稿はあなただけに見えています',
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .bodyMedium!
+                                              .copyWith(
+                                                color: Theme.of(context)
+                                                    .colorScheme
+                                                    .onSurfaceVariant,
+                                                fontWeight: FontWeight.bold,
+                                              ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                                const SizedBox(height: 8),
+                              ],
+                            ),
+                          ),
                     InkWell(
                       onTap: () async {
                         await context.pushRoute(

--- a/lib/feature/definition/presentation/page/definition_detail/definition_detail_page.dart
+++ b/lib/feature/definition/presentation/page/definition_detail/definition_detail_page.dart
@@ -165,45 +165,6 @@ class DefinitionDetailPage extends ConsumerWidget {
                         ),
                       ],
                     ),
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          definition.updatedAt.toDisplayFormat(),
-                          style: Theme.of(context).textTheme.bodyMedium,
-                        ),
-                        const SizedBox(width: 2),
-                        Text(
-                          '更新',
-                          style: Theme.of(context).textTheme.bodyMedium,
-                        ),
-                        definition.isEdited
-                            ? Row(
-                                children: [
-                                  const SizedBox(width: 8),
-                                  Text(
-                                    '編集済み',
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .bodyMedium!
-                                        .copyWith(
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .onSurfaceVariant,
-                                        ),
-                                  ),
-                                  Icon(
-                                    CupertinoIcons.pencil,
-                                    size: 16,
-                                    color: Theme.of(context)
-                                        .colorScheme
-                                        .onSurfaceVariant,
-                                  ),
-                                ],
-                              )
-                            : const SizedBox.shrink(),
-                      ],
-                    ),
                     const SizedBox(height: 8),
                     LikeWidget(definition: definition),
                   ],

--- a/lib/feature/definition/repository/entity/definition_document.dart
+++ b/lib/feature/definition/repository/entity/definition_document.dart
@@ -14,6 +14,7 @@ class DefinitionDocument with _$DefinitionDocument {
     required String definition,
     required int likesCount,
     required bool isPublic,
+    required bool isEdited,
     required DateTime createdAt,
     required DateTime updatedAt,
   }) = _DefinitionDocument;
@@ -27,6 +28,7 @@ class DefinitionDocument with _$DefinitionDocument {
       definition: data[DefinitionsCollection.definition] as String,
       likesCount: data[DefinitionsCollection.likesCount] as int,
       isPublic: data[DefinitionsCollection.isPublic] as bool,
+      isEdited: data[DefinitionsCollection.isEdited] as bool,
       createdAt: (data[createdAtFieldName] as Timestamp).toDate(),
       updatedAt: (data[updatedAtFieldName] as Timestamp).toDate(),
     );

--- a/lib/feature/definition/repository/entity/definition_document.freezed.dart
+++ b/lib/feature/definition/repository/entity/definition_document.freezed.dart
@@ -22,6 +22,7 @@ mixin _$DefinitionDocument {
   String get definition => throw _privateConstructorUsedError;
   int get likesCount => throw _privateConstructorUsedError;
   bool get isPublic => throw _privateConstructorUsedError;
+  bool get isEdited => throw _privateConstructorUsedError;
   DateTime get createdAt => throw _privateConstructorUsedError;
   DateTime get updatedAt => throw _privateConstructorUsedError;
 
@@ -43,6 +44,7 @@ abstract class $DefinitionDocumentCopyWith<$Res> {
       String definition,
       int likesCount,
       bool isPublic,
+      bool isEdited,
       DateTime createdAt,
       DateTime updatedAt});
 }
@@ -66,6 +68,7 @@ class _$DefinitionDocumentCopyWithImpl<$Res, $Val extends DefinitionDocument>
     Object? definition = null,
     Object? likesCount = null,
     Object? isPublic = null,
+    Object? isEdited = null,
     Object? createdAt = null,
     Object? updatedAt = null,
   }) {
@@ -94,6 +97,10 @@ class _$DefinitionDocumentCopyWithImpl<$Res, $Val extends DefinitionDocument>
           ? _value.isPublic
           : isPublic // ignore: cast_nullable_to_non_nullable
               as bool,
+      isEdited: null == isEdited
+          ? _value.isEdited
+          : isEdited // ignore: cast_nullable_to_non_nullable
+              as bool,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -121,6 +128,7 @@ abstract class _$$_DefinitionDocumentCopyWith<$Res>
       String definition,
       int likesCount,
       bool isPublic,
+      bool isEdited,
       DateTime createdAt,
       DateTime updatedAt});
 }
@@ -142,6 +150,7 @@ class __$$_DefinitionDocumentCopyWithImpl<$Res>
     Object? definition = null,
     Object? likesCount = null,
     Object? isPublic = null,
+    Object? isEdited = null,
     Object? createdAt = null,
     Object? updatedAt = null,
   }) {
@@ -170,6 +179,10 @@ class __$$_DefinitionDocumentCopyWithImpl<$Res>
           ? _value.isPublic
           : isPublic // ignore: cast_nullable_to_non_nullable
               as bool,
+      isEdited: null == isEdited
+          ? _value.isEdited
+          : isEdited // ignore: cast_nullable_to_non_nullable
+              as bool,
       createdAt: null == createdAt
           ? _value.createdAt
           : createdAt // ignore: cast_nullable_to_non_nullable
@@ -192,6 +205,7 @@ class _$_DefinitionDocument implements _DefinitionDocument {
       required this.definition,
       required this.likesCount,
       required this.isPublic,
+      required this.isEdited,
       required this.createdAt,
       required this.updatedAt});
 
@@ -208,13 +222,15 @@ class _$_DefinitionDocument implements _DefinitionDocument {
   @override
   final bool isPublic;
   @override
+  final bool isEdited;
+  @override
   final DateTime createdAt;
   @override
   final DateTime updatedAt;
 
   @override
   String toString() {
-    return 'DefinitionDocument(id: $id, wordId: $wordId, authorId: $authorId, definition: $definition, likesCount: $likesCount, isPublic: $isPublic, createdAt: $createdAt, updatedAt: $updatedAt)';
+    return 'DefinitionDocument(id: $id, wordId: $wordId, authorId: $authorId, definition: $definition, likesCount: $likesCount, isPublic: $isPublic, isEdited: $isEdited, createdAt: $createdAt, updatedAt: $updatedAt)';
   }
 
   @override
@@ -232,6 +248,8 @@ class _$_DefinitionDocument implements _DefinitionDocument {
                 other.likesCount == likesCount) &&
             (identical(other.isPublic, isPublic) ||
                 other.isPublic == isPublic) &&
+            (identical(other.isEdited, isEdited) ||
+                other.isEdited == isEdited) &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
             (identical(other.updatedAt, updatedAt) ||
@@ -240,7 +258,7 @@ class _$_DefinitionDocument implements _DefinitionDocument {
 
   @override
   int get hashCode => Object.hash(runtimeType, id, wordId, authorId, definition,
-      likesCount, isPublic, createdAt, updatedAt);
+      likesCount, isPublic, isEdited, createdAt, updatedAt);
 
   @JsonKey(ignore: true)
   @override
@@ -258,6 +276,7 @@ abstract class _DefinitionDocument implements DefinitionDocument {
       required final String definition,
       required final int likesCount,
       required final bool isPublic,
+      required final bool isEdited,
       required final DateTime createdAt,
       required final DateTime updatedAt}) = _$_DefinitionDocument;
 
@@ -273,6 +292,8 @@ abstract class _DefinitionDocument implements DefinitionDocument {
   int get likesCount;
   @override
   bool get isPublic;
+  @override
+  bool get isEdited;
   @override
   DateTime get createdAt;
   @override

--- a/lib/feature/user_profile/presentation/page/profile/profile_widget.dart
+++ b/lib/feature/user_profile/presentation/page/profile/profile_widget.dart
@@ -82,7 +82,7 @@ class ProfileWidget extends ConsumerWidget {
               const SizedBox(height: 16),
               Text(
                 targetUserProfile.bio,
-                style: Theme.of(context).textTheme.bodyLarge,
+                style: Theme.of(context).textTheme.bodyMedium,
               ),
               const SizedBox(height: 24),
               Align(

--- a/lib/feature/word/application/word_state.g.dart
+++ b/lib/feature/word/application/word_state.g.dart
@@ -6,7 +6,7 @@ part of 'word_state.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$wordHash() => r'b2210ba303039f93528ea5103948deedfdf75a3c';
+String _$wordHash() => r'c1da987087d1c757d9c7f9dd91bec61de24cc5cf';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/feature/word/presentation/page/word_top/word_widget.dart
+++ b/lib/feature/word/presentation/page/word_top/word_widget.dart
@@ -25,11 +25,11 @@ class WordWidget extends ConsumerWidget {
                 word.word,
                 style: Theme.of(context).textTheme.titleLarge,
               ),
-              const SizedBox(height: 8),
               Text(
                 word.reading,
-                style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                style: Theme.of(context).textTheme.titleSmall!.copyWith(
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      fontWeight: FontWeight.bold,
                     ),
               ),
               const SizedBox(height: 24),

--- a/lib/util/constant/firestore_collections.dart
+++ b/lib/util/constant/firestore_collections.dart
@@ -25,7 +25,7 @@ class DefinitionsCollection {
   static const definition = 'definition';
   static const likesCount = 'likesCount';
   static const isPublic = 'isPublic';
-  // static const isEdited = 'isEdited';
+  static const isEdited = 'isEdited';
 }
 
 class LikesCollection {

--- a/lib/util/constant/text_theme.dart
+++ b/lib/util/constant/text_theme.dart
@@ -7,4 +7,7 @@ const textTheme = TextTheme(
   titleMedium: TextStyle(
     fontWeight: FontWeight.bold,
   ),
+  bodyLarge: TextStyle(
+    fontSize: 18,
+  ),
 );

--- a/lib/util/dummy_data/definitions_dummy.dart
+++ b/lib/util/dummy_data/definitions_dummy.dart
@@ -124,6 +124,7 @@ Future<void> addDefinitionDummy0to29(String flavorName) async {
       'definition': definitions[i],
       'likesCount': Random().nextInt(100),
       'isPublic': Random().nextBool(),
+      'isEdited': false,
       'createdAt': FieldValue.serverTimestamp(),
       'updatedAt': FieldValue.serverTimestamp(),
     });

--- a/test/feature/definition/application/definition_state_test.dart
+++ b/test/feature/definition/application/definition_state_test.dart
@@ -94,11 +94,9 @@ void main() {
         authorImageUrl: mockUserProfileDoc.profileImageUrl,
         definition: mockDefinitionDoc.definition,
         isPublic: mockDefinitionDoc.isPublic,
-        isEdited: mockDefinitionDoc.isEdited,
         likesCount: mockDefinitionDoc.likesCount,
         isLikedByUser: isLikedByUser,
         createdAt: mockDefinitionDoc.createdAt,
-        updatedAt: mockDefinitionDoc.updatedAt,
       );
       // stateの検証
       verifyInOrder([

--- a/test/feature/definition/application/definition_state_test.dart
+++ b/test/feature/definition/application/definition_state_test.dart
@@ -94,6 +94,7 @@ void main() {
         authorImageUrl: mockUserProfileDoc.profileImageUrl,
         definition: mockDefinitionDoc.definition,
         isPublic: mockDefinitionDoc.isPublic,
+        isEdited: mockDefinitionDoc.isEdited,
         likesCount: mockDefinitionDoc.likesCount,
         isLikedByUser: isLikedByUser,
         createdAt: mockDefinitionDoc.createdAt,

--- a/test/mock/mock_data.dart
+++ b/test/mock/mock_data.dart
@@ -23,6 +23,7 @@ final mockDefinition = Definition(
   authorImageUrl: 'authorImageUrl',
   definition: 'definition',
   isPublic: true,
+  isEdited: false,
   likesCount: 0,
   isLikedByUser: false,
   createdAt: nowDateTime,
@@ -36,6 +37,7 @@ final mockDefinitionDoc = DefinitionDocument(
   definition: 'content',
   likesCount: 0,
   isPublic: true,
+  isEdited: false,
   createdAt: nowDateTime,
   updatedAt: nowDateTime,
 );

--- a/test/mock/mock_data.dart
+++ b/test/mock/mock_data.dart
@@ -23,11 +23,9 @@ final mockDefinition = Definition(
   authorImageUrl: 'authorImageUrl',
   definition: 'definition',
   isPublic: true,
-  isEdited: false,
   likesCount: 0,
   isLikedByUser: false,
   createdAt: nowDateTime,
-  updatedAt: nowDateTime,
 );
 
 final mockDefinitionDoc = DefinitionDocument(


### PR DESCRIPTION
# 対象Issue

- #68 

# やった事

- isEditedをFirestoreに保存するよう更新
- 非公開であることを表示させるよう更新
- updatedAtをUIに表示させないよう更新

# やらなかった事

- 編集済みであることをUIで表示
→ 不要だと判断したため

# 動作確認

- iPhone11 (実機) で実施

# その他

