### PR TITLE
いいねしたユーザー一覧を実装

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -12,6 +12,7 @@ import '../../feature/definition/util/write_definition_form_type.dart';
 import '../../feature/setting/presentation/license_page.dart';
 import '../../feature/setting/presentation/setting_page.dart';
 import '../../feature/user_profile/presentation/page/following_and_follower_list/following_and_follower_list_page.dart';
+import '../../feature/user_profile/presentation/page/like_user_page.dart/like_user_page.dart';
 import '../../feature/user_profile/presentation/page/profile/profile_page.dart';
 import '../../feature/word/presentation/page/index_second/index_second_page.dart';
 import '../../feature/word/presentation/page/index_top/index_top_page.dart';
@@ -25,7 +26,6 @@ part 'app_router.gr.dart';
 
 @riverpod
 Raw<AppRouter> appRouter(AppRouterRef ref) => AppRouter();
-
 
 // TODO(me): 一部Routeのpathにidを含める
 @AutoRouterConfig(replaceInRouteName: 'Page,Route')
@@ -47,6 +47,10 @@ class AppRouter extends _$AppRouter {
                 AutoRoute(
                   path: 'definition_detail',
                   page: DefinitionDetailRoute.page,
+                ),
+                AutoRoute(
+                  path: 'like_user_list',
+                  page: LikeUserRoute.page,
                 ),
                 AutoRoute(
                   path: 'word_top',
@@ -73,6 +77,10 @@ class AppRouter extends _$AppRouter {
                 AutoRoute(
                   path: 'definition_detail',
                   page: DefinitionDetailRoute.page,
+                ),
+                AutoRoute(
+                  path: 'like_user_list',
+                  page: LikeUserRoute.page,
                 ),
                 AutoRoute(
                   path: 'word_top',
@@ -107,6 +115,10 @@ class AppRouter extends _$AppRouter {
                 AutoRoute(
                   path: 'definition_detail',
                   page: DefinitionDetailRoute.page,
+                ),
+                AutoRoute(
+                  path: 'like_user_list',
+                  page: LikeUserRoute.page,
                 ),
                 AutoRoute(
                   path: 'word_top',

--- a/lib/core/router/app_router.gr.dart
+++ b/lib/core/router/app_router.gr.dart
@@ -92,6 +92,16 @@ abstract class _$AppRouter extends RootStackRouter {
         child: const IndexTopRouterPage(),
       );
     },
+    LikeUserRoute.name: (routeData) {
+      final args = routeData.argsAs<LikeUserRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: LikeUserPage(
+          key: args.key,
+          definitionId: args.definitionId,
+        ),
+      );
+    },
     MyLicenseRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
@@ -411,6 +421,44 @@ class IndexTopRouterRoute extends PageRouteInfo<void> {
   static const String name = 'IndexTopRouterRoute';
 
   static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [LikeUserPage]
+class LikeUserRoute extends PageRouteInfo<LikeUserRouteArgs> {
+  LikeUserRoute({
+    Key? key,
+    required String definitionId,
+    List<PageRouteInfo>? children,
+  }) : super(
+          LikeUserRoute.name,
+          args: LikeUserRouteArgs(
+            key: key,
+            definitionId: definitionId,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'LikeUserRoute';
+
+  static const PageInfo<LikeUserRouteArgs> page =
+      PageInfo<LikeUserRouteArgs>(name);
+}
+
+class LikeUserRouteArgs {
+  const LikeUserRouteArgs({
+    this.key,
+    required this.definitionId,
+  });
+
+  final Key? key;
+
+  final String definitionId;
+
+  @override
+  String toString() {
+    return 'LikeUserRouteArgs{key: $key, definitionId: $definitionId}';
+  }
 }
 
 /// generated route for

--- a/lib/feature/definition/application/definition_id_list_state.dart
+++ b/lib/feature/definition/application/definition_id_list_state.dart
@@ -123,7 +123,7 @@ class DefinitionIdListStateNotifier extends _$DefinitionIdListStateNotifier
 
       case DefinitionFeedType.wordTopOrderByCreatedAt:
         if (wordId == null) {
-          throw Exception('wordIdがnullです');
+          throw ArgumentError('wordIdがnullです');
         }
 
         return _fetchForWordTop(
@@ -133,7 +133,7 @@ class DefinitionIdListStateNotifier extends _$DefinitionIdListStateNotifier
 
       case DefinitionFeedType.wordTopOrderByLikesCount:
         if (wordId == null) {
-          throw Exception('wordIdがnullです');
+          throw ArgumentError('wordIdがnullです');
         }
 
         return _fetchForWordTop(

--- a/lib/feature/definition/application/definition_id_list_state.g.dart
+++ b/lib/feature/definition/application/definition_id_list_state.g.dart
@@ -7,7 +7,7 @@ part of 'definition_id_list_state.dart';
 // **************************************************************************
 
 String _$definitionIdListStateNotifierHash() =>
-    r'4804844313b4aa6a383887ae43c94debf1d278a5';
+    r'9487bc668b045c50e7629cf86d91254ddd21f2f1';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/feature/definition/application/definition_state.g.dart
+++ b/lib/feature/definition/application/definition_state.g.dart
@@ -6,7 +6,7 @@ part of 'definition_state.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$definitionHash() => r'bc272c27067ab2006dee9d8da745423adc7fd59f';
+String _$definitionHash() => r'd667422ac57af03ac4e1fc761b60d41b144dee8b';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/feature/definition/presentation/component/like_widget.dart
+++ b/lib/feature/definition/presentation/component/like_widget.dart
@@ -12,9 +12,11 @@ class LikeWidget extends ConsumerWidget {
   const LikeWidget({
     super.key,
     required this.definition,
+    this.showCount = true,
   });
 
   final Definition definition;
+  final bool showCount;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -25,8 +27,8 @@ class LikeWidget extends ConsumerWidget {
         LikeButton(
           isLiked: definition.isLikedByUser,
           likeCount: definition.likesCount,
-          likeCountPadding: const EdgeInsets.only(
-            right: 24,
+          likeCountPadding: EdgeInsets.only(
+            right: showCount ? 24 : 0,
           ),
           likeBuilder: (bool isLiked) {
             return Icon(
@@ -37,14 +39,17 @@ class LikeWidget extends ConsumerWidget {
             );
           },
           countBuilder: (int? count, bool isLiked, String text) {
-            return Text(
-              text,
-              style: TextStyle(
-                fontSize: 16,
-                color:
-                    isLiked ? likeColor : Theme.of(context).colorScheme.outline,
-              ),
-            );
+            return showCount
+                ? Text(
+                    text,
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: isLiked
+                          ? likeColor
+                          : Theme.of(context).colorScheme.outline,
+                    ),
+                  )
+                : const SizedBox.shrink();
           },
           onTap: (_) async {
             try {

--- a/lib/feature/definition/presentation/page/definition_detail/definition_detail_page.dart
+++ b/lib/feature/definition/presentation/page/definition_detail/definition_detail_page.dart
@@ -154,19 +154,32 @@ class DefinitionDetailPage extends ConsumerWidget {
                     const SizedBox(height: 48),
                     Row(
                       children: [
-                        Text(
-                          definition.createdAt.toDisplayFormat(),
-                          style: Theme.of(context).textTheme.bodyMedium,
-                        ),
-                        const SizedBox(width: 2),
-                        Text(
-                          '投稿',
-                          style: Theme.of(context).textTheme.bodyMedium,
+                        LikeWidget(definition: definition, showCount: false),
+                        InkWell(
+                          onTap: () async {
+                            await context.pushRoute(
+                              LikeUserRoute(definitionId: definition.id),
+                            );
+                          },
+                          child: Text('${definition.likesCount}件のいいね'),
                         ),
                       ],
                     ),
                     const SizedBox(height: 8),
-                    LikeWidget(definition: definition),
+                    const SizedBox(height: 24),
+                    Row(
+                      children: [
+                        Text(
+                          '${definition.createdAt.toDisplayFormat()} 投稿',
+                          style:
+                              Theme.of(context).textTheme.bodyMedium!.copyWith(
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onSurfaceVariant,
+                                  ),
+                        ),
+                      ],
+                    ),
                   ],
                 ),
               ),

--- a/lib/feature/user_profile/application/user_id_list_state.dart
+++ b/lib/feature/user_profile/application/user_id_list_state.dart
@@ -15,7 +15,7 @@ class UserIdListStateNotifier extends _$UserIdListStateNotifier
   FutureOr<UserIdListState> build(
     UserListType userListType, {
     required String? targetUserId,
-    required String? definitionId,
+    required String? targetDefinitionId,
   }) async {
     return await _fetchUserIdListStateBasedOnType(
       isFirstFetch: true,
@@ -61,12 +61,11 @@ class UserIdListStateNotifier extends _$UserIdListStateNotifier
             );
 
       case UserListType.likedUser:
-        if (definitionId == null) {
-          throw ArgumentError('definitionIdがnullです');
+        if (targetDefinitionId == null) {
+          throw ArgumentError('targetDefinitionIdがnullです');
         }
-        // TODO(me): いいねしたユーザー一覧を取得するよう修正する
         return ref.read(definitionRepositoryProvider).fetchFavoriteUserIdList(
-              definitionId!,
+              targetDefinitionId!,
               lastDocument,
             );
     }

--- a/lib/feature/user_profile/application/user_id_list_state.g.dart
+++ b/lib/feature/user_profile/application/user_id_list_state.g.dart
@@ -7,7 +7,7 @@ part of 'user_id_list_state.dart';
 // **************************************************************************
 
 String _$userIdListStateNotifierHash() =>
-    r'c8fa0d4162a3591bf3faaad00b35856ad79fd82a';
+    r'b44533a5622901906fc13b124538de8271a3d747';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -34,12 +34,12 @@ abstract class _$UserIdListStateNotifier
     extends BuildlessAutoDisposeAsyncNotifier<UserIdListState> {
   late final UserListType userListType;
   late final String? targetUserId;
-  late final String? definitionId;
+  late final String? targetDefinitionId;
 
   FutureOr<UserIdListState> build(
     UserListType userListType, {
     required String? targetUserId,
-    required String? definitionId,
+    required String? targetDefinitionId,
   });
 }
 
@@ -57,12 +57,12 @@ class UserIdListStateNotifierFamily
   UserIdListStateNotifierProvider call(
     UserListType userListType, {
     required String? targetUserId,
-    required String? definitionId,
+    required String? targetDefinitionId,
   }) {
     return UserIdListStateNotifierProvider(
       userListType,
       targetUserId: targetUserId,
-      definitionId: definitionId,
+      targetDefinitionId: targetDefinitionId,
     );
   }
 
@@ -73,7 +73,7 @@ class UserIdListStateNotifierFamily
     return call(
       provider.userListType,
       targetUserId: provider.targetUserId,
-      definitionId: provider.definitionId,
+      targetDefinitionId: provider.targetDefinitionId,
     );
   }
 
@@ -100,12 +100,12 @@ class UserIdListStateNotifierProvider
   UserIdListStateNotifierProvider(
     UserListType userListType, {
     required String? targetUserId,
-    required String? definitionId,
+    required String? targetDefinitionId,
   }) : this._internal(
           () => UserIdListStateNotifier()
             ..userListType = userListType
             ..targetUserId = targetUserId
-            ..definitionId = definitionId,
+            ..targetDefinitionId = targetDefinitionId,
           from: userIdListStateNotifierProvider,
           name: r'userIdListStateNotifierProvider',
           debugGetCreateSourceHash:
@@ -117,7 +117,7 @@ class UserIdListStateNotifierProvider
               UserIdListStateNotifierFamily._allTransitiveDependencies,
           userListType: userListType,
           targetUserId: targetUserId,
-          definitionId: definitionId,
+          targetDefinitionId: targetDefinitionId,
         );
 
   UserIdListStateNotifierProvider._internal(
@@ -129,12 +129,12 @@ class UserIdListStateNotifierProvider
     required super.from,
     required this.userListType,
     required this.targetUserId,
-    required this.definitionId,
+    required this.targetDefinitionId,
   }) : super.internal();
 
   final UserListType userListType;
   final String? targetUserId;
-  final String? definitionId;
+  final String? targetDefinitionId;
 
   @override
   FutureOr<UserIdListState> runNotifierBuild(
@@ -143,7 +143,7 @@ class UserIdListStateNotifierProvider
     return notifier.build(
       userListType,
       targetUserId: targetUserId,
-      definitionId: definitionId,
+      targetDefinitionId: targetDefinitionId,
     );
   }
 
@@ -155,7 +155,7 @@ class UserIdListStateNotifierProvider
         () => create()
           ..userListType = userListType
           ..targetUserId = targetUserId
-          ..definitionId = definitionId,
+          ..targetDefinitionId = targetDefinitionId,
         from: from,
         name: null,
         dependencies: null,
@@ -163,7 +163,7 @@ class UserIdListStateNotifierProvider
         debugGetCreateSourceHash: null,
         userListType: userListType,
         targetUserId: targetUserId,
-        definitionId: definitionId,
+        targetDefinitionId: targetDefinitionId,
       ),
     );
   }
@@ -179,7 +179,7 @@ class UserIdListStateNotifierProvider
     return other is UserIdListStateNotifierProvider &&
         other.userListType == userListType &&
         other.targetUserId == targetUserId &&
-        other.definitionId == definitionId;
+        other.targetDefinitionId == targetDefinitionId;
   }
 
   @override
@@ -187,7 +187,7 @@ class UserIdListStateNotifierProvider
     var hash = _SystemHash.combine(0, runtimeType.hashCode);
     hash = _SystemHash.combine(hash, userListType.hashCode);
     hash = _SystemHash.combine(hash, targetUserId.hashCode);
-    hash = _SystemHash.combine(hash, definitionId.hashCode);
+    hash = _SystemHash.combine(hash, targetDefinitionId.hashCode);
 
     return _SystemHash.finish(hash);
   }
@@ -201,8 +201,8 @@ mixin UserIdListStateNotifierRef
   /// The parameter `targetUserId` of this provider.
   String? get targetUserId;
 
-  /// The parameter `definitionId` of this provider.
-  String? get definitionId;
+  /// The parameter `targetDefinitionId` of this provider.
+  String? get targetDefinitionId;
 }
 
 class _UserIdListStateNotifierProviderElement
@@ -217,8 +217,8 @@ class _UserIdListStateNotifierProviderElement
   String? get targetUserId =>
       (origin as UserIdListStateNotifierProvider).targetUserId;
   @override
-  String? get definitionId =>
-      (origin as UserIdListStateNotifierProvider).definitionId;
+  String? get targetDefinitionId =>
+      (origin as UserIdListStateNotifierProvider).targetDefinitionId;
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/user_profile/application/user_id_list_state.g.dart
+++ b/lib/feature/user_profile/application/user_id_list_state.g.dart
@@ -7,7 +7,7 @@ part of 'user_id_list_state.dart';
 // **************************************************************************
 
 String _$userIdListStateNotifierHash() =>
-    r'64bf38fadfff24df7903e73dc596dcff305d38ac';
+    r'c8fa0d4162a3591bf3faaad00b35856ad79fd82a';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -33,12 +33,14 @@ class _SystemHash {
 abstract class _$UserIdListStateNotifier
     extends BuildlessAutoDisposeAsyncNotifier<UserIdListState> {
   late final UserListType userListType;
-  late final String targetUserId;
+  late final String? targetUserId;
+  late final String? definitionId;
 
   FutureOr<UserIdListState> build(
-    UserListType userListType,
-    String targetUserId,
-  );
+    UserListType userListType, {
+    required String? targetUserId,
+    required String? definitionId,
+  });
 }
 
 /// See also [UserIdListStateNotifier].
@@ -53,12 +55,14 @@ class UserIdListStateNotifierFamily
 
   /// See also [UserIdListStateNotifier].
   UserIdListStateNotifierProvider call(
-    UserListType userListType,
-    String targetUserId,
-  ) {
+    UserListType userListType, {
+    required String? targetUserId,
+    required String? definitionId,
+  }) {
     return UserIdListStateNotifierProvider(
       userListType,
-      targetUserId,
+      targetUserId: targetUserId,
+      definitionId: definitionId,
     );
   }
 
@@ -68,7 +72,8 @@ class UserIdListStateNotifierFamily
   ) {
     return call(
       provider.userListType,
-      provider.targetUserId,
+      targetUserId: provider.targetUserId,
+      definitionId: provider.definitionId,
     );
   }
 
@@ -93,12 +98,14 @@ class UserIdListStateNotifierProvider
         UserIdListState> {
   /// See also [UserIdListStateNotifier].
   UserIdListStateNotifierProvider(
-    UserListType userListType,
-    String targetUserId,
-  ) : this._internal(
+    UserListType userListType, {
+    required String? targetUserId,
+    required String? definitionId,
+  }) : this._internal(
           () => UserIdListStateNotifier()
             ..userListType = userListType
-            ..targetUserId = targetUserId,
+            ..targetUserId = targetUserId
+            ..definitionId = definitionId,
           from: userIdListStateNotifierProvider,
           name: r'userIdListStateNotifierProvider',
           debugGetCreateSourceHash:
@@ -110,6 +117,7 @@ class UserIdListStateNotifierProvider
               UserIdListStateNotifierFamily._allTransitiveDependencies,
           userListType: userListType,
           targetUserId: targetUserId,
+          definitionId: definitionId,
         );
 
   UserIdListStateNotifierProvider._internal(
@@ -121,10 +129,12 @@ class UserIdListStateNotifierProvider
     required super.from,
     required this.userListType,
     required this.targetUserId,
+    required this.definitionId,
   }) : super.internal();
 
   final UserListType userListType;
-  final String targetUserId;
+  final String? targetUserId;
+  final String? definitionId;
 
   @override
   FutureOr<UserIdListState> runNotifierBuild(
@@ -132,7 +142,8 @@ class UserIdListStateNotifierProvider
   ) {
     return notifier.build(
       userListType,
-      targetUserId,
+      targetUserId: targetUserId,
+      definitionId: definitionId,
     );
   }
 
@@ -143,7 +154,8 @@ class UserIdListStateNotifierProvider
       override: UserIdListStateNotifierProvider._internal(
         () => create()
           ..userListType = userListType
-          ..targetUserId = targetUserId,
+          ..targetUserId = targetUserId
+          ..definitionId = definitionId,
         from: from,
         name: null,
         dependencies: null,
@@ -151,6 +163,7 @@ class UserIdListStateNotifierProvider
         debugGetCreateSourceHash: null,
         userListType: userListType,
         targetUserId: targetUserId,
+        definitionId: definitionId,
       ),
     );
   }
@@ -165,7 +178,8 @@ class UserIdListStateNotifierProvider
   bool operator ==(Object other) {
     return other is UserIdListStateNotifierProvider &&
         other.userListType == userListType &&
-        other.targetUserId == targetUserId;
+        other.targetUserId == targetUserId &&
+        other.definitionId == definitionId;
   }
 
   @override
@@ -173,6 +187,7 @@ class UserIdListStateNotifierProvider
     var hash = _SystemHash.combine(0, runtimeType.hashCode);
     hash = _SystemHash.combine(hash, userListType.hashCode);
     hash = _SystemHash.combine(hash, targetUserId.hashCode);
+    hash = _SystemHash.combine(hash, definitionId.hashCode);
 
     return _SystemHash.finish(hash);
   }
@@ -184,7 +199,10 @@ mixin UserIdListStateNotifierRef
   UserListType get userListType;
 
   /// The parameter `targetUserId` of this provider.
-  String get targetUserId;
+  String? get targetUserId;
+
+  /// The parameter `definitionId` of this provider.
+  String? get definitionId;
 }
 
 class _UserIdListStateNotifierProviderElement
@@ -196,8 +214,11 @@ class _UserIdListStateNotifierProviderElement
   UserListType get userListType =>
       (origin as UserIdListStateNotifierProvider).userListType;
   @override
-  String get targetUserId =>
+  String? get targetUserId =>
       (origin as UserIdListStateNotifierProvider).targetUserId;
+  @override
+  String? get definitionId =>
+      (origin as UserIdListStateNotifierProvider).definitionId;
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/user_profile/presentation/component/profile_list.dart
+++ b/lib/feature/user_profile/presentation/component/profile_list.dart
@@ -2,23 +2,25 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../../core/common_widget/cupertino_refresh_indicator.dart';
-import '../../../../../core/common_widget/infinite_scroll_bottom_indicator.dart';
-import '../../../../../util/logger.dart';
-import '../../../application/user_id_list_state.dart';
-import '../../../util/profile_feed_type.dart';
-import 'profile_tile.dart';
+import '../../../../core/common_widget/cupertino_refresh_indicator.dart';
+import '../../../../core/common_widget/infinite_scroll_bottom_indicator.dart';
+import '../../../../util/logger.dart';
+import '../../application/user_id_list_state.dart';
+import '../../util/profile_feed_type.dart';
+import '../page/following_and_follower_list/profile_tile.dart';
 
 class ProfileList extends ConsumerWidget {
   ProfileList({
     super.key,
     required this.userListType,
     required this.targetUserId,
+    required this.targetDefinitionId,
   });
-
-  final String targetUserId;
-
+  
   final UserListType userListType;
+  final String? targetUserId;
+  final String? targetDefinitionId;
+
   final scrollController = ScrollController();
   // エラーが発生してリビルドした際、スクロール位置を保持するためのキー
   final globalKey = GlobalKey();
@@ -29,7 +31,7 @@ class ProfileList extends ConsumerWidget {
       UserIdListStateNotifierProvider(
         userListType,
         targetUserId: targetUserId,
-        definitionId: null,
+        targetDefinitionId: targetDefinitionId,
       ),
     );
 
@@ -46,7 +48,7 @@ class ProfileList extends ConsumerWidget {
                     userIdListStateNotifierProvider(
                       userListType,
                       targetUserId: targetUserId,
-                      definitionId: null,
+                      targetDefinitionId: targetDefinitionId,
                     ).notifier,
                   )
                   .fetchMore();
@@ -66,7 +68,7 @@ class ProfileList extends ConsumerWidget {
                       userIdListStateNotifierProvider(
                         userListType,
                         targetUserId: targetUserId,
-                        definitionId: null,
+                        targetDefinitionId: targetDefinitionId,
                       ),
                     );
                   },

--- a/lib/feature/user_profile/presentation/page/following_and_follower_list/following_and_follower_list_page.dart
+++ b/lib/feature/user_profile/presentation/page/following_and_follower_list/following_and_follower_list_page.dart
@@ -6,7 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../../core/common_widget/stickey_tab_bar_deligate.dart';
 import '../../../../auth/application/auth_state.dart';
 import '../../../util/profile_feed_type.dart';
-import 'profile_list.dart';
+import '../../component/profile_list.dart';
 
 @RoutePage()
 class FollowingAndFollowerListPage extends ConsumerWidget {
@@ -71,10 +71,12 @@ class FollowingAndFollowerListPage extends ConsumerWidget {
                 ProfileList(
                   userListType: UserListType.following,
                   targetUserId: targetUserId,
+                  targetDefinitionId: null,
                 ),
                 ProfileList(
                   userListType: UserListType.follower,
                   targetUserId: targetUserId,
+                  targetDefinitionId: null,
                 ),
               ],
             ),

--- a/lib/feature/user_profile/presentation/page/following_and_follower_list/profile_list.dart
+++ b/lib/feature/user_profile/presentation/page/following_and_follower_list/profile_list.dart
@@ -25,8 +25,13 @@ class ProfileList extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncUserIdListState =
-        ref.watch(UserIdListStateNotifierProvider(userListType, targetUserId));
+    final asyncUserIdListState = ref.watch(
+      UserIdListStateNotifierProvider(
+        userListType,
+        targetUserId: targetUserId,
+        definitionId: null,
+      ),
+    );
 
     return asyncUserIdListState.when(
       data: (userIdListState) {
@@ -38,8 +43,11 @@ class ProfileList extends ConsumerWidget {
             if (notification.metrics.extentAfter == 0) {
               ref
                   .read(
-                    userIdListStateNotifierProvider(userListType, targetUserId)
-                        .notifier,
+                    userIdListStateNotifierProvider(
+                      userListType,
+                      targetUserId: targetUserId,
+                      definitionId: null,
+                    ).notifier,
                   )
                   .fetchMore();
               return true;
@@ -57,7 +65,8 @@ class ProfileList extends ConsumerWidget {
                     ref.invalidate(
                       userIdListStateNotifierProvider(
                         userListType,
-                        targetUserId,
+                        targetUserId: targetUserId,
+                        definitionId: null,
                       ),
                     );
                   },

--- a/lib/feature/user_profile/presentation/page/like_user_page.dart/like_user_page.dart
+++ b/lib/feature/user_profile/presentation/page/like_user_page.dart/like_user_page.dart
@@ -1,0 +1,29 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../util/profile_feed_type.dart';
+import '../../component/profile_list.dart';
+
+@RoutePage()
+class LikeUserPage extends ConsumerWidget {
+  const LikeUserPage({
+    super.key,
+    required this.definitionId,
+  });
+  final String definitionId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('いいね！'),
+      ),
+      body: ProfileList(
+        userListType: UserListType.likedUser,
+        targetUserId: null,
+        targetDefinitionId: definitionId,
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,6 @@ import 'firebase_options/firebase_options.dart';
 import 'util/constant/color_scheme.dart';
 import 'util/constant/tab_bar_theme.dart';
 import 'util/constant/text_theme.dart';
-import 'util/dummy_data/likes_dummy.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'firebase_options/firebase_options.dart';
 import 'util/constant/color_scheme.dart';
 import 'util/constant/tab_bar_theme.dart';
 import 'util/constant/text_theme.dart';
+import 'util/dummy_data/likes_dummy.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -47,6 +48,7 @@ Future<void> main() async {
   // await addWordsDummy0to29(flavorName);
   // await addWordsDummy30to59(flavorName);
   // await addDefinitionDummy0to29(flavorName);
+  // await addLikesToFirestore(flavorName);
 
   runApp(
     const ProviderScope(

--- a/lib/util/dummy_data/likes_dummy.dart
+++ b/lib/util/dummy_data/likes_dummy.dart
@@ -1,0 +1,22 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../constant/firestore_collections.dart';
+
+Future<void> addLikesToFirestore(String flavorName) async {
+  if (flavorName == 'prod') {
+    return;
+  }
+
+  final firestore = FirebaseFirestore.instance;
+
+  // 上で定義したusersマップを用いてデータをFirestoreに追加
+  for (var i = 1; i <= 20; i++) {
+    await firestore.collection(LikesCollection.collectionName).add({
+      LikesCollection.definitionId: 'OnEjul4BHX5YtTCXFbHq',
+      LikesCollection.userId: 'user$i',
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+    await Future<void>.delayed(const Duration(milliseconds: 1000));
+  }
+}

--- a/test/feature/auth/application/auth_service_test.mocks.dart
+++ b/test/feature/auth/application/auth_service_test.mocks.dart
@@ -284,51 +284,26 @@ class MockUserFollowRepository extends _i1.Mock
       ) as _i9.Future<List<String>>);
 
   @override
-  _i9.Future<_i5.UserIdListState> fetchFollowingIdListFirst(String? userId) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #fetchFollowingIdListFirst,
-          [userId],
-        ),
-        returnValue:
-            _i9.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
-          this,
-          Invocation.method(
-            #fetchFollowingIdListFirst,
-            [userId],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i9.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
-          this,
-          Invocation.method(
-            #fetchFollowingIdListFirst,
-            [userId],
-          ),
-        )),
-      ) as _i9.Future<_i5.UserIdListState>);
-
-  @override
-  _i9.Future<_i5.UserIdListState> fetchFollowingIdListMore(
+  _i9.Future<_i5.UserIdListState> fetchFollowingIdList(
     String? userId,
-    _i2.QueryDocumentSnapshot<Object?>? lastReadQueryDocumentSnapshot,
+    _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchFollowingIdListMore,
+          #fetchFollowingIdList,
           [
             userId,
-            lastReadQueryDocumentSnapshot,
+            lastDocument,
           ],
         ),
         returnValue:
             _i9.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
           this,
           Invocation.method(
-            #fetchFollowingIdListMore,
+            #fetchFollowingIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),
@@ -336,61 +311,36 @@ class MockUserFollowRepository extends _i1.Mock
             _i9.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
           this,
           Invocation.method(
-            #fetchFollowingIdListMore,
+            #fetchFollowingIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),
       ) as _i9.Future<_i5.UserIdListState>);
 
   @override
-  _i9.Future<_i5.UserIdListState> fetchFollowerIdListFirst(String? userId) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #fetchFollowerIdListFirst,
-          [userId],
-        ),
-        returnValue:
-            _i9.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
-          this,
-          Invocation.method(
-            #fetchFollowerIdListFirst,
-            [userId],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i9.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
-          this,
-          Invocation.method(
-            #fetchFollowerIdListFirst,
-            [userId],
-          ),
-        )),
-      ) as _i9.Future<_i5.UserIdListState>);
-
-  @override
-  _i9.Future<_i5.UserIdListState> fetchFollowerIdListMore(
+  _i9.Future<_i5.UserIdListState> fetchFollowerIdList(
     String? userId,
-    _i2.QueryDocumentSnapshot<Object?>? lastReadQueryDocumentSnapshot,
+    _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchFollowerIdListMore,
+          #fetchFollowerIdList,
           [
             userId,
-            lastReadQueryDocumentSnapshot,
+            lastDocument,
           ],
         ),
         returnValue:
             _i9.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
           this,
           Invocation.method(
-            #fetchFollowerIdListMore,
+            #fetchFollowerIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),
@@ -398,10 +348,10 @@ class MockUserFollowRepository extends _i1.Mock
             _i9.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
           this,
           Invocation.method(
-            #fetchFollowerIdListMore,
+            #fetchFollowerIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),

--- a/test/feature/definition/application/definition_id_list_state_test.mocks.dart
+++ b/test/feature/definition/application/definition_id_list_state_test.mocks.dart
@@ -19,15 +19,15 @@ import 'package:teigi_app/feature/definition/repository/entity/definition_docume
 import 'package:teigi_app/feature/definition/util/definition_feed_type.dart'
     as _i13;
 import 'package:teigi_app/feature/user_config/repository/entity/user_config_document.dart'
-    as _i6;
+    as _i7;
 import 'package:teigi_app/feature/user_config/repository/user_config_repository.dart'
     as _i16;
 import 'package:teigi_app/feature/user_profile/domain/user_id_list_state.dart'
-    as _i8;
-import 'package:teigi_app/feature/user_profile/repository/entity/user_follow_count_document.dart'
-    as _i7;
-import 'package:teigi_app/feature/user_profile/repository/entity/user_profile_document.dart'
     as _i5;
+import 'package:teigi_app/feature/user_profile/repository/entity/user_follow_count_document.dart'
+    as _i8;
+import 'package:teigi_app/feature/user_profile/repository/entity/user_profile_document.dart'
+    as _i6;
 import 'package:teigi_app/feature/user_profile/repository/user_follow_repository.dart'
     as _i17;
 import 'package:teigi_app/feature/user_profile/repository/user_profile_repository.dart'
@@ -83,9 +83,9 @@ class _FakeDefinitionDocument_2 extends _i1.SmartFake
         );
 }
 
-class _FakeUserProfileDocument_3 extends _i1.SmartFake
-    implements _i5.UserProfileDocument {
-  _FakeUserProfileDocument_3(
+class _FakeUserIdListState_3 extends _i1.SmartFake
+    implements _i5.UserIdListState {
+  _FakeUserIdListState_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -94,9 +94,9 @@ class _FakeUserProfileDocument_3 extends _i1.SmartFake
         );
 }
 
-class _FakeUserConfigDocument_4 extends _i1.SmartFake
-    implements _i6.UserConfigDocument {
-  _FakeUserConfigDocument_4(
+class _FakeUserProfileDocument_4 extends _i1.SmartFake
+    implements _i6.UserProfileDocument {
+  _FakeUserProfileDocument_4(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -105,9 +105,9 @@ class _FakeUserConfigDocument_4 extends _i1.SmartFake
         );
 }
 
-class _FakeUserFollowCountDocument_5 extends _i1.SmartFake
-    implements _i7.UserFollowCountDocument {
-  _FakeUserFollowCountDocument_5(
+class _FakeUserConfigDocument_5 extends _i1.SmartFake
+    implements _i7.UserConfigDocument {
+  _FakeUserConfigDocument_5(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -116,9 +116,9 @@ class _FakeUserFollowCountDocument_5 extends _i1.SmartFake
         );
 }
 
-class _FakeUserIdListState_6 extends _i1.SmartFake
-    implements _i8.UserIdListState {
-  _FakeUserIdListState_6(
+class _FakeUserFollowCountDocument_6 extends _i1.SmartFake
+    implements _i8.UserFollowCountDocument {
+  _FakeUserFollowCountDocument_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -326,6 +326,43 @@ class MockDefinitionRepository extends _i1.Mock
       ) as _i12.Future<_i4.DefinitionDocument>);
 
   @override
+  _i12.Future<_i5.UserIdListState> fetchFavoriteUserIdList(
+    String? definitionId,
+    _i2.QueryDocumentSnapshot<Object?>? lastDocument,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #fetchFavoriteUserIdList,
+          [
+            definitionId,
+            lastDocument,
+          ],
+        ),
+        returnValue:
+            _i12.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
+          this,
+          Invocation.method(
+            #fetchFavoriteUserIdList,
+            [
+              definitionId,
+              lastDocument,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i12.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
+          this,
+          Invocation.method(
+            #fetchFavoriteUserIdList,
+            [
+              definitionId,
+              lastDocument,
+            ],
+          ),
+        )),
+      ) as _i12.Future<_i5.UserIdListState>);
+
+  @override
   _i12.Future<void> createDefinitionAndMaybeWord(
     String? authorId,
     String? existingWordId,
@@ -432,29 +469,29 @@ class MockUserProfileRepository extends _i1.Mock
       ) as _i2.FirebaseFirestore);
 
   @override
-  _i12.Future<_i5.UserProfileDocument> fetchUserProfile(String? userId) =>
+  _i12.Future<_i6.UserProfileDocument> fetchUserProfile(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchUserProfile,
           [userId],
         ),
-        returnValue: _i12.Future<_i5.UserProfileDocument>.value(
-            _FakeUserProfileDocument_3(
+        returnValue: _i12.Future<_i6.UserProfileDocument>.value(
+            _FakeUserProfileDocument_4(
           this,
           Invocation.method(
             #fetchUserProfile,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i5.UserProfileDocument>.value(
-            _FakeUserProfileDocument_3(
+        returnValueForMissingStub: _i12.Future<_i6.UserProfileDocument>.value(
+            _FakeUserProfileDocument_4(
           this,
           Invocation.method(
             #fetchUserProfile,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i5.UserProfileDocument>);
+      ) as _i12.Future<_i6.UserProfileDocument>);
 
   @override
   _i12.Future<void> addUserProfile(
@@ -493,14 +530,14 @@ class MockUserConfigRepository extends _i1.Mock
       ) as _i2.FirebaseFirestore);
 
   @override
-  _i12.Future<_i6.UserConfigDocument> fetchUserConfig(String? userId) =>
+  _i12.Future<_i7.UserConfigDocument> fetchUserConfig(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchUserConfig,
           [userId],
         ),
         returnValue:
-            _i12.Future<_i6.UserConfigDocument>.value(_FakeUserConfigDocument_4(
+            _i12.Future<_i7.UserConfigDocument>.value(_FakeUserConfigDocument_5(
           this,
           Invocation.method(
             #fetchUserConfig,
@@ -508,14 +545,14 @@ class MockUserConfigRepository extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i6.UserConfigDocument>.value(_FakeUserConfigDocument_4(
+            _i12.Future<_i7.UserConfigDocument>.value(_FakeUserConfigDocument_5(
           this,
           Invocation.method(
             #fetchUserConfig,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i6.UserConfigDocument>);
+      ) as _i12.Future<_i7.UserConfigDocument>);
 
   @override
   _i12.Future<void> addUserConfig(
@@ -609,15 +646,15 @@ class MockUserFollowRepository extends _i1.Mock
       ) as _i2.FirebaseFirestore);
 
   @override
-  _i12.Future<_i7.UserFollowCountDocument> fetchUserFollowCount(
+  _i12.Future<_i8.UserFollowCountDocument> fetchUserFollowCount(
           String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchUserFollowCount,
           [userId],
         ),
-        returnValue: _i12.Future<_i7.UserFollowCountDocument>.value(
-            _FakeUserFollowCountDocument_5(
+        returnValue: _i12.Future<_i8.UserFollowCountDocument>.value(
+            _FakeUserFollowCountDocument_6(
           this,
           Invocation.method(
             #fetchUserFollowCount,
@@ -625,15 +662,15 @@ class MockUserFollowRepository extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i7.UserFollowCountDocument>.value(
-                _FakeUserFollowCountDocument_5(
+            _i12.Future<_i8.UserFollowCountDocument>.value(
+                _FakeUserFollowCountDocument_6(
           this,
           Invocation.method(
             #fetchUserFollowCount,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i7.UserFollowCountDocument>);
+      ) as _i12.Future<_i8.UserFollowCountDocument>);
 
   @override
   _i12.Future<void> follow(
@@ -708,128 +745,78 @@ class MockUserFollowRepository extends _i1.Mock
       ) as _i12.Future<List<String>>);
 
   @override
-  _i12.Future<_i8.UserIdListState> fetchFollowingIdListFirst(String? userId) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #fetchFollowingIdListFirst,
-          [userId],
-        ),
-        returnValue:
-            _i12.Future<_i8.UserIdListState>.value(_FakeUserIdListState_6(
-          this,
-          Invocation.method(
-            #fetchFollowingIdListFirst,
-            [userId],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i12.Future<_i8.UserIdListState>.value(_FakeUserIdListState_6(
-          this,
-          Invocation.method(
-            #fetchFollowingIdListFirst,
-            [userId],
-          ),
-        )),
-      ) as _i12.Future<_i8.UserIdListState>);
-
-  @override
-  _i12.Future<_i8.UserIdListState> fetchFollowingIdListMore(
+  _i12.Future<_i5.UserIdListState> fetchFollowingIdList(
     String? userId,
-    _i2.QueryDocumentSnapshot<Object?>? lastReadQueryDocumentSnapshot,
+    _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchFollowingIdListMore,
+          #fetchFollowingIdList,
           [
             userId,
-            lastReadQueryDocumentSnapshot,
+            lastDocument,
           ],
         ),
         returnValue:
-            _i12.Future<_i8.UserIdListState>.value(_FakeUserIdListState_6(
+            _i12.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
           this,
           Invocation.method(
-            #fetchFollowingIdListMore,
+            #fetchFollowingIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i8.UserIdListState>.value(_FakeUserIdListState_6(
+            _i12.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
           this,
           Invocation.method(
-            #fetchFollowingIdListMore,
+            #fetchFollowingIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),
-      ) as _i12.Future<_i8.UserIdListState>);
+      ) as _i12.Future<_i5.UserIdListState>);
 
   @override
-  _i12.Future<_i8.UserIdListState> fetchFollowerIdListFirst(String? userId) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #fetchFollowerIdListFirst,
-          [userId],
-        ),
-        returnValue:
-            _i12.Future<_i8.UserIdListState>.value(_FakeUserIdListState_6(
-          this,
-          Invocation.method(
-            #fetchFollowerIdListFirst,
-            [userId],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i12.Future<_i8.UserIdListState>.value(_FakeUserIdListState_6(
-          this,
-          Invocation.method(
-            #fetchFollowerIdListFirst,
-            [userId],
-          ),
-        )),
-      ) as _i12.Future<_i8.UserIdListState>);
-
-  @override
-  _i12.Future<_i8.UserIdListState> fetchFollowerIdListMore(
+  _i12.Future<_i5.UserIdListState> fetchFollowerIdList(
     String? userId,
-    _i2.QueryDocumentSnapshot<Object?>? lastReadQueryDocumentSnapshot,
+    _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchFollowerIdListMore,
+          #fetchFollowerIdList,
           [
             userId,
-            lastReadQueryDocumentSnapshot,
+            lastDocument,
           ],
         ),
         returnValue:
-            _i12.Future<_i8.UserIdListState>.value(_FakeUserIdListState_6(
+            _i12.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
           this,
           Invocation.method(
-            #fetchFollowerIdListMore,
+            #fetchFollowerIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i8.UserIdListState>.value(_FakeUserIdListState_6(
+            _i12.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
           this,
           Invocation.method(
-            #fetchFollowerIdListMore,
+            #fetchFollowerIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),
-      ) as _i12.Future<_i8.UserIdListState>);
+      ) as _i12.Future<_i5.UserIdListState>);
 }
 
 /// A class which mocks [WordRepository].

--- a/test/feature/definition/application/definition_service_test.mocks.dart
+++ b/test/feature/definition/application/definition_service_test.mocks.dart
@@ -3,23 +3,25 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i6;
+import 'dart:async' as _i7;
 
 import 'package:cloud_firestore/cloud_firestore.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:riverpod_annotation/riverpod_annotation.dart' as _i10;
+import 'package:riverpod_annotation/riverpod_annotation.dart' as _i11;
 import 'package:teigi_app/feature/definition/domain/definition_for_write.dart'
-    as _i8;
+    as _i9;
 import 'package:teigi_app/feature/definition/domain/definition_id_list_state.dart'
     as _i3;
 import 'package:teigi_app/feature/definition/repository/definition_repository.dart'
-    as _i5;
+    as _i6;
 import 'package:teigi_app/feature/definition/repository/entity/definition_document.dart'
     as _i4;
 import 'package:teigi_app/feature/definition/util/definition_feed_type.dart'
-    as _i7;
+    as _i8;
+import 'package:teigi_app/feature/user_profile/domain/user_id_list_state.dart'
+    as _i5;
 
-import 'definition_service_test.dart' as _i9;
+import 'definition_service_test.dart' as _i10;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -65,11 +67,22 @@ class _FakeDefinitionDocument_2 extends _i1.SmartFake
         );
 }
 
+class _FakeUserIdListState_3 extends _i1.SmartFake
+    implements _i5.UserIdListState {
+  _FakeUserIdListState_3(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [DefinitionRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockDefinitionRepository extends _i1.Mock
-    implements _i5.DefinitionRepository {
+    implements _i6.DefinitionRepository {
   @override
   _i2.FirebaseFirestore get firestore => (super.noSuchMethod(
         Invocation.getter(#firestore),
@@ -84,7 +97,7 @@ class MockDefinitionRepository extends _i1.Mock
       ) as _i2.FirebaseFirestore);
 
   @override
-  _i6.Future<_i3.DefinitionIdListState> fetchHomeRecommendDefinitionIdListState(
+  _i7.Future<_i3.DefinitionIdListState> fetchHomeRecommendDefinitionIdListState(
     String? currentUserId,
     List<String>? mutedUserIdList,
     _i2.QueryDocumentSnapshot<Object?>? lastDocument,
@@ -98,7 +111,7 @@ class MockDefinitionRepository extends _i1.Mock
             lastDocument,
           ],
         ),
-        returnValue: _i6.Future<_i3.DefinitionIdListState>.value(
+        returnValue: _i7.Future<_i3.DefinitionIdListState>.value(
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
@@ -110,7 +123,7 @@ class MockDefinitionRepository extends _i1.Mock
             ],
           ),
         )),
-        returnValueForMissingStub: _i6.Future<_i3.DefinitionIdListState>.value(
+        returnValueForMissingStub: _i7.Future<_i3.DefinitionIdListState>.value(
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
@@ -122,10 +135,10 @@ class MockDefinitionRepository extends _i1.Mock
             ],
           ),
         )),
-      ) as _i6.Future<_i3.DefinitionIdListState>);
+      ) as _i7.Future<_i3.DefinitionIdListState>);
 
   @override
-  _i6.Future<_i3.DefinitionIdListState> fetchHomeFollowingDefinitionIdListState(
+  _i7.Future<_i3.DefinitionIdListState> fetchHomeFollowingDefinitionIdListState(
     String? currentUserId,
     List<String>? targetUserIdList,
     _i2.QueryDocumentSnapshot<Object?>? lastDocument,
@@ -139,7 +152,7 @@ class MockDefinitionRepository extends _i1.Mock
             lastDocument,
           ],
         ),
-        returnValue: _i6.Future<_i3.DefinitionIdListState>.value(
+        returnValue: _i7.Future<_i3.DefinitionIdListState>.value(
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
@@ -151,7 +164,7 @@ class MockDefinitionRepository extends _i1.Mock
             ],
           ),
         )),
-        returnValueForMissingStub: _i6.Future<_i3.DefinitionIdListState>.value(
+        returnValueForMissingStub: _i7.Future<_i3.DefinitionIdListState>.value(
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
@@ -163,11 +176,11 @@ class MockDefinitionRepository extends _i1.Mock
             ],
           ),
         )),
-      ) as _i6.Future<_i3.DefinitionIdListState>);
+      ) as _i7.Future<_i3.DefinitionIdListState>);
 
   @override
-  _i6.Future<_i3.DefinitionIdListState> fetchWordTopDefinitionIdListState(
-    _i7.WordTopOrderByType? orderByType,
+  _i7.Future<_i3.DefinitionIdListState> fetchWordTopDefinitionIdListState(
+    _i8.WordTopOrderByType? orderByType,
     String? currentUserId,
     List<String>? mutedUserIdList,
     String? wordId,
@@ -184,7 +197,7 @@ class MockDefinitionRepository extends _i1.Mock
             lastDocument,
           ],
         ),
-        returnValue: _i6.Future<_i3.DefinitionIdListState>.value(
+        returnValue: _i7.Future<_i3.DefinitionIdListState>.value(
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
@@ -198,7 +211,7 @@ class MockDefinitionRepository extends _i1.Mock
             ],
           ),
         )),
-        returnValueForMissingStub: _i6.Future<_i3.DefinitionIdListState>.value(
+        returnValueForMissingStub: _i7.Future<_i3.DefinitionIdListState>.value(
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
@@ -212,17 +225,17 @@ class MockDefinitionRepository extends _i1.Mock
             ],
           ),
         )),
-      ) as _i6.Future<_i3.DefinitionIdListState>);
+      ) as _i7.Future<_i3.DefinitionIdListState>);
 
   @override
-  _i6.Future<_i4.DefinitionDocument> fetchDefinition(String? definitionId) =>
+  _i7.Future<_i4.DefinitionDocument> fetchDefinition(String? definitionId) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchDefinition,
           [definitionId],
         ),
         returnValue:
-            _i6.Future<_i4.DefinitionDocument>.value(_FakeDefinitionDocument_2(
+            _i7.Future<_i4.DefinitionDocument>.value(_FakeDefinitionDocument_2(
           this,
           Invocation.method(
             #fetchDefinition,
@@ -230,20 +243,57 @@ class MockDefinitionRepository extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<_i4.DefinitionDocument>.value(_FakeDefinitionDocument_2(
+            _i7.Future<_i4.DefinitionDocument>.value(_FakeDefinitionDocument_2(
           this,
           Invocation.method(
             #fetchDefinition,
             [definitionId],
           ),
         )),
-      ) as _i6.Future<_i4.DefinitionDocument>);
+      ) as _i7.Future<_i4.DefinitionDocument>);
 
   @override
-  _i6.Future<void> createDefinitionAndMaybeWord(
+  _i7.Future<_i5.UserIdListState> fetchFavoriteUserIdList(
+    String? definitionId,
+    _i2.QueryDocumentSnapshot<Object?>? lastDocument,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #fetchFavoriteUserIdList,
+          [
+            definitionId,
+            lastDocument,
+          ],
+        ),
+        returnValue:
+            _i7.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
+          this,
+          Invocation.method(
+            #fetchFavoriteUserIdList,
+            [
+              definitionId,
+              lastDocument,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i7.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
+          this,
+          Invocation.method(
+            #fetchFavoriteUserIdList,
+            [
+              definitionId,
+              lastDocument,
+            ],
+          ),
+        )),
+      ) as _i7.Future<_i5.UserIdListState>);
+
+  @override
+  _i7.Future<void> createDefinitionAndMaybeWord(
     String? authorId,
     String? existingWordId,
-    _i8.DefinitionForWrite? definitionForWrite,
+    _i9.DefinitionForWrite? definitionForWrite,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -254,14 +304,14 @@ class MockDefinitionRepository extends _i1.Mock
             definitionForWrite,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> updateDefinitionAndMaybeCreateWord(
+  _i7.Future<void> updateDefinitionAndMaybeCreateWord(
     String? existingWordId,
-    _i8.DefinitionForWrite? definitionForWrite,
+    _i9.DefinitionForWrite? definitionForWrite,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -271,12 +321,12 @@ class MockDefinitionRepository extends _i1.Mock
             definitionForWrite,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> likeDefinition(
+  _i7.Future<void> likeDefinition(
     String? definitionId,
     String? userId,
   ) =>
@@ -288,12 +338,12 @@ class MockDefinitionRepository extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> unlikeDefinition(
+  _i7.Future<void> unlikeDefinition(
     String? definitionId,
     String? userId,
   ) =>
@@ -305,12 +355,12 @@ class MockDefinitionRepository extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<bool> isLikedByUser(
+  _i7.Future<bool> isLikedByUser(
     String? userId,
     String? definitionId,
   ) =>
@@ -322,20 +372,20 @@ class MockDefinitionRepository extends _i1.Mock
             definitionId,
           ],
         ),
-        returnValue: _i6.Future<bool>.value(false),
-        returnValueForMissingStub: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+        returnValue: _i7.Future<bool>.value(false),
+        returnValueForMissingStub: _i7.Future<bool>.value(false),
+      ) as _i7.Future<bool>);
 }
 
 /// A class which mocks [Listener].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockListener extends _i1.Mock
-    implements _i9.Listener<_i10.AsyncValue<void>> {
+    implements _i10.Listener<_i11.AsyncValue<void>> {
   @override
   void call(
-    _i10.AsyncValue<void>? previous,
-    _i10.AsyncValue<void>? next,
+    _i11.AsyncValue<void>? previous,
+    _i11.AsyncValue<void>? next,
   ) =>
       super.noSuchMethod(
         Invocation.method(

--- a/test/feature/definition/application/definition_state_test.mocks.dart
+++ b/test/feature/definition/application/definition_state_test.mocks.dart
@@ -3,32 +3,34 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i9;
+import 'dart:async' as _i10;
 
 import 'package:cloud_firestore/cloud_firestore.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:riverpod_annotation/riverpod_annotation.dart' as _i15;
-import 'package:teigi_app/feature/definition/domain/definition.dart' as _i16;
+import 'package:riverpod_annotation/riverpod_annotation.dart' as _i16;
+import 'package:teigi_app/feature/definition/domain/definition.dart' as _i17;
 import 'package:teigi_app/feature/definition/domain/definition_for_write.dart'
-    as _i11;
+    as _i12;
 import 'package:teigi_app/feature/definition/domain/definition_id_list_state.dart'
     as _i3;
 import 'package:teigi_app/feature/definition/repository/definition_repository.dart'
-    as _i8;
+    as _i9;
 import 'package:teigi_app/feature/definition/repository/entity/definition_document.dart'
     as _i4;
 import 'package:teigi_app/feature/definition/util/definition_feed_type.dart'
-    as _i10;
-import 'package:teigi_app/feature/user_profile/repository/entity/user_profile_document.dart'
+    as _i11;
+import 'package:teigi_app/feature/user_profile/domain/user_id_list_state.dart'
     as _i5;
-import 'package:teigi_app/feature/user_profile/repository/user_profile_repository.dart'
-    as _i12;
-import 'package:teigi_app/feature/word/domain/word_list_state.dart' as _i7;
-import 'package:teigi_app/feature/word/repository/entity/word_document.dart'
+import 'package:teigi_app/feature/user_profile/repository/entity/user_profile_document.dart'
     as _i6;
-import 'package:teigi_app/feature/word/repository/word_repository.dart' as _i13;
+import 'package:teigi_app/feature/user_profile/repository/user_profile_repository.dart'
+    as _i13;
+import 'package:teigi_app/feature/word/domain/word_list_state.dart' as _i8;
+import 'package:teigi_app/feature/word/repository/entity/word_document.dart'
+    as _i7;
+import 'package:teigi_app/feature/word/repository/word_repository.dart' as _i14;
 
-import 'definition_state_test.dart' as _i14;
+import 'definition_state_test.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -74,9 +76,9 @@ class _FakeDefinitionDocument_2 extends _i1.SmartFake
         );
 }
 
-class _FakeUserProfileDocument_3 extends _i1.SmartFake
-    implements _i5.UserProfileDocument {
-  _FakeUserProfileDocument_3(
+class _FakeUserIdListState_3 extends _i1.SmartFake
+    implements _i5.UserIdListState {
+  _FakeUserIdListState_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -85,8 +87,9 @@ class _FakeUserProfileDocument_3 extends _i1.SmartFake
         );
 }
 
-class _FakeWordDocument_4 extends _i1.SmartFake implements _i6.WordDocument {
-  _FakeWordDocument_4(
+class _FakeUserProfileDocument_4 extends _i1.SmartFake
+    implements _i6.UserProfileDocument {
+  _FakeUserProfileDocument_4(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -95,8 +98,18 @@ class _FakeWordDocument_4 extends _i1.SmartFake implements _i6.WordDocument {
         );
 }
 
-class _FakeWordListState_5 extends _i1.SmartFake implements _i7.WordListState {
-  _FakeWordListState_5(
+class _FakeWordDocument_5 extends _i1.SmartFake implements _i7.WordDocument {
+  _FakeWordDocument_5(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeWordListState_6 extends _i1.SmartFake implements _i8.WordListState {
+  _FakeWordListState_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -109,7 +122,7 @@ class _FakeWordListState_5 extends _i1.SmartFake implements _i7.WordListState {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockDefinitionRepository extends _i1.Mock
-    implements _i8.DefinitionRepository {
+    implements _i9.DefinitionRepository {
   @override
   _i2.FirebaseFirestore get firestore => (super.noSuchMethod(
         Invocation.getter(#firestore),
@@ -124,90 +137,94 @@ class MockDefinitionRepository extends _i1.Mock
       ) as _i2.FirebaseFirestore);
 
   @override
-  _i9.Future<_i3.DefinitionIdListState> fetchHomeRecommendDefinitionIdListState(
+  _i10.Future<_i3.DefinitionIdListState>
+      fetchHomeRecommendDefinitionIdListState(
     String? currentUserId,
     List<String>? mutedUserIdList,
     _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #fetchHomeRecommendDefinitionIdListState,
-          [
-            currentUserId,
-            mutedUserIdList,
-            lastDocument,
-          ],
-        ),
-        returnValue: _i9.Future<_i3.DefinitionIdListState>.value(
-            _FakeDefinitionIdListState_1(
-          this,
-          Invocation.method(
-            #fetchHomeRecommendDefinitionIdListState,
-            [
-              currentUserId,
-              mutedUserIdList,
-              lastDocument,
-            ],
-          ),
-        )),
-        returnValueForMissingStub: _i9.Future<_i3.DefinitionIdListState>.value(
-            _FakeDefinitionIdListState_1(
-          this,
-          Invocation.method(
-            #fetchHomeRecommendDefinitionIdListState,
-            [
-              currentUserId,
-              mutedUserIdList,
-              lastDocument,
-            ],
-          ),
-        )),
-      ) as _i9.Future<_i3.DefinitionIdListState>);
+          (super.noSuchMethod(
+            Invocation.method(
+              #fetchHomeRecommendDefinitionIdListState,
+              [
+                currentUserId,
+                mutedUserIdList,
+                lastDocument,
+              ],
+            ),
+            returnValue: _i10.Future<_i3.DefinitionIdListState>.value(
+                _FakeDefinitionIdListState_1(
+              this,
+              Invocation.method(
+                #fetchHomeRecommendDefinitionIdListState,
+                [
+                  currentUserId,
+                  mutedUserIdList,
+                  lastDocument,
+                ],
+              ),
+            )),
+            returnValueForMissingStub:
+                _i10.Future<_i3.DefinitionIdListState>.value(
+                    _FakeDefinitionIdListState_1(
+              this,
+              Invocation.method(
+                #fetchHomeRecommendDefinitionIdListState,
+                [
+                  currentUserId,
+                  mutedUserIdList,
+                  lastDocument,
+                ],
+              ),
+            )),
+          ) as _i10.Future<_i3.DefinitionIdListState>);
 
   @override
-  _i9.Future<_i3.DefinitionIdListState> fetchHomeFollowingDefinitionIdListState(
+  _i10.Future<_i3.DefinitionIdListState>
+      fetchHomeFollowingDefinitionIdListState(
     String? currentUserId,
     List<String>? targetUserIdList,
     _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #fetchHomeFollowingDefinitionIdListState,
-          [
-            currentUserId,
-            targetUserIdList,
-            lastDocument,
-          ],
-        ),
-        returnValue: _i9.Future<_i3.DefinitionIdListState>.value(
-            _FakeDefinitionIdListState_1(
-          this,
-          Invocation.method(
-            #fetchHomeFollowingDefinitionIdListState,
-            [
-              currentUserId,
-              targetUserIdList,
-              lastDocument,
-            ],
-          ),
-        )),
-        returnValueForMissingStub: _i9.Future<_i3.DefinitionIdListState>.value(
-            _FakeDefinitionIdListState_1(
-          this,
-          Invocation.method(
-            #fetchHomeFollowingDefinitionIdListState,
-            [
-              currentUserId,
-              targetUserIdList,
-              lastDocument,
-            ],
-          ),
-        )),
-      ) as _i9.Future<_i3.DefinitionIdListState>);
+          (super.noSuchMethod(
+            Invocation.method(
+              #fetchHomeFollowingDefinitionIdListState,
+              [
+                currentUserId,
+                targetUserIdList,
+                lastDocument,
+              ],
+            ),
+            returnValue: _i10.Future<_i3.DefinitionIdListState>.value(
+                _FakeDefinitionIdListState_1(
+              this,
+              Invocation.method(
+                #fetchHomeFollowingDefinitionIdListState,
+                [
+                  currentUserId,
+                  targetUserIdList,
+                  lastDocument,
+                ],
+              ),
+            )),
+            returnValueForMissingStub:
+                _i10.Future<_i3.DefinitionIdListState>.value(
+                    _FakeDefinitionIdListState_1(
+              this,
+              Invocation.method(
+                #fetchHomeFollowingDefinitionIdListState,
+                [
+                  currentUserId,
+                  targetUserIdList,
+                  lastDocument,
+                ],
+              ),
+            )),
+          ) as _i10.Future<_i3.DefinitionIdListState>);
 
   @override
-  _i9.Future<_i3.DefinitionIdListState> fetchWordTopDefinitionIdListState(
-    _i10.WordTopOrderByType? orderByType,
+  _i10.Future<_i3.DefinitionIdListState> fetchWordTopDefinitionIdListState(
+    _i11.WordTopOrderByType? orderByType,
     String? currentUserId,
     List<String>? mutedUserIdList,
     String? wordId,
@@ -224,7 +241,7 @@ class MockDefinitionRepository extends _i1.Mock
             lastDocument,
           ],
         ),
-        returnValue: _i9.Future<_i3.DefinitionIdListState>.value(
+        returnValue: _i10.Future<_i3.DefinitionIdListState>.value(
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
@@ -238,7 +255,7 @@ class MockDefinitionRepository extends _i1.Mock
             ],
           ),
         )),
-        returnValueForMissingStub: _i9.Future<_i3.DefinitionIdListState>.value(
+        returnValueForMissingStub: _i10.Future<_i3.DefinitionIdListState>.value(
             _FakeDefinitionIdListState_1(
           this,
           Invocation.method(
@@ -252,17 +269,17 @@ class MockDefinitionRepository extends _i1.Mock
             ],
           ),
         )),
-      ) as _i9.Future<_i3.DefinitionIdListState>);
+      ) as _i10.Future<_i3.DefinitionIdListState>);
 
   @override
-  _i9.Future<_i4.DefinitionDocument> fetchDefinition(String? definitionId) =>
+  _i10.Future<_i4.DefinitionDocument> fetchDefinition(String? definitionId) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchDefinition,
           [definitionId],
         ),
         returnValue:
-            _i9.Future<_i4.DefinitionDocument>.value(_FakeDefinitionDocument_2(
+            _i10.Future<_i4.DefinitionDocument>.value(_FakeDefinitionDocument_2(
           this,
           Invocation.method(
             #fetchDefinition,
@@ -270,20 +287,57 @@ class MockDefinitionRepository extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i9.Future<_i4.DefinitionDocument>.value(_FakeDefinitionDocument_2(
+            _i10.Future<_i4.DefinitionDocument>.value(_FakeDefinitionDocument_2(
           this,
           Invocation.method(
             #fetchDefinition,
             [definitionId],
           ),
         )),
-      ) as _i9.Future<_i4.DefinitionDocument>);
+      ) as _i10.Future<_i4.DefinitionDocument>);
 
   @override
-  _i9.Future<void> createDefinitionAndMaybeWord(
+  _i10.Future<_i5.UserIdListState> fetchFavoriteUserIdList(
+    String? definitionId,
+    _i2.QueryDocumentSnapshot<Object?>? lastDocument,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #fetchFavoriteUserIdList,
+          [
+            definitionId,
+            lastDocument,
+          ],
+        ),
+        returnValue:
+            _i10.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
+          this,
+          Invocation.method(
+            #fetchFavoriteUserIdList,
+            [
+              definitionId,
+              lastDocument,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i10.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
+          this,
+          Invocation.method(
+            #fetchFavoriteUserIdList,
+            [
+              definitionId,
+              lastDocument,
+            ],
+          ),
+        )),
+      ) as _i10.Future<_i5.UserIdListState>);
+
+  @override
+  _i10.Future<void> createDefinitionAndMaybeWord(
     String? authorId,
     String? existingWordId,
-    _i11.DefinitionForWrite? definitionForWrite,
+    _i12.DefinitionForWrite? definitionForWrite,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -294,14 +348,14 @@ class MockDefinitionRepository extends _i1.Mock
             definitionForWrite,
           ],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i10.Future<void>.value(),
+        returnValueForMissingStub: _i10.Future<void>.value(),
+      ) as _i10.Future<void>);
 
   @override
-  _i9.Future<void> updateDefinitionAndMaybeCreateWord(
+  _i10.Future<void> updateDefinitionAndMaybeCreateWord(
     String? existingWordId,
-    _i11.DefinitionForWrite? definitionForWrite,
+    _i12.DefinitionForWrite? definitionForWrite,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -311,12 +365,12 @@ class MockDefinitionRepository extends _i1.Mock
             definitionForWrite,
           ],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i10.Future<void>.value(),
+        returnValueForMissingStub: _i10.Future<void>.value(),
+      ) as _i10.Future<void>);
 
   @override
-  _i9.Future<void> likeDefinition(
+  _i10.Future<void> likeDefinition(
     String? definitionId,
     String? userId,
   ) =>
@@ -328,12 +382,12 @@ class MockDefinitionRepository extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i10.Future<void>.value(),
+        returnValueForMissingStub: _i10.Future<void>.value(),
+      ) as _i10.Future<void>);
 
   @override
-  _i9.Future<void> unlikeDefinition(
+  _i10.Future<void> unlikeDefinition(
     String? definitionId,
     String? userId,
   ) =>
@@ -345,12 +399,12 @@ class MockDefinitionRepository extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i10.Future<void>.value(),
+        returnValueForMissingStub: _i10.Future<void>.value(),
+      ) as _i10.Future<void>);
 
   @override
-  _i9.Future<bool> isLikedByUser(
+  _i10.Future<bool> isLikedByUser(
     String? userId,
     String? definitionId,
   ) =>
@@ -362,16 +416,16 @@ class MockDefinitionRepository extends _i1.Mock
             definitionId,
           ],
         ),
-        returnValue: _i9.Future<bool>.value(false),
-        returnValueForMissingStub: _i9.Future<bool>.value(false),
-      ) as _i9.Future<bool>);
+        returnValue: _i10.Future<bool>.value(false),
+        returnValueForMissingStub: _i10.Future<bool>.value(false),
+      ) as _i10.Future<bool>);
 }
 
 /// A class which mocks [UserProfileRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockUserProfileRepository extends _i1.Mock
-    implements _i12.UserProfileRepository {
+    implements _i13.UserProfileRepository {
   @override
   _i2.FirebaseFirestore get firestore => (super.noSuchMethod(
         Invocation.getter(#firestore),
@@ -386,32 +440,32 @@ class MockUserProfileRepository extends _i1.Mock
       ) as _i2.FirebaseFirestore);
 
   @override
-  _i9.Future<_i5.UserProfileDocument> fetchUserProfile(String? userId) =>
+  _i10.Future<_i6.UserProfileDocument> fetchUserProfile(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchUserProfile,
           [userId],
         ),
-        returnValue: _i9.Future<_i5.UserProfileDocument>.value(
-            _FakeUserProfileDocument_3(
+        returnValue: _i10.Future<_i6.UserProfileDocument>.value(
+            _FakeUserProfileDocument_4(
           this,
           Invocation.method(
             #fetchUserProfile,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i9.Future<_i5.UserProfileDocument>.value(
-            _FakeUserProfileDocument_3(
+        returnValueForMissingStub: _i10.Future<_i6.UserProfileDocument>.value(
+            _FakeUserProfileDocument_4(
           this,
           Invocation.method(
             #fetchUserProfile,
             [userId],
           ),
         )),
-      ) as _i9.Future<_i5.UserProfileDocument>);
+      ) as _i10.Future<_i6.UserProfileDocument>);
 
   @override
-  _i9.Future<void> addUserProfile(
+  _i10.Future<void> addUserProfile(
     String? userId,
     String? name,
   ) =>
@@ -423,15 +477,15 @@ class MockUserProfileRepository extends _i1.Mock
             name,
           ],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i10.Future<void>.value(),
+        returnValueForMissingStub: _i10.Future<void>.value(),
+      ) as _i10.Future<void>);
 }
 
 /// A class which mocks [WordRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockWordRepository extends _i1.Mock implements _i13.WordRepository {
+class MockWordRepository extends _i1.Mock implements _i14.WordRepository {
   @override
   _i2.FirebaseFirestore get firestore => (super.noSuchMethod(
         Invocation.getter(#firestore),
@@ -446,13 +500,13 @@ class MockWordRepository extends _i1.Mock implements _i13.WordRepository {
       ) as _i2.FirebaseFirestore);
 
   @override
-  _i9.Future<_i6.WordDocument> fetchWordById(String? wordId) =>
+  _i10.Future<_i7.WordDocument> fetchWordById(String? wordId) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchWordById,
           [wordId],
         ),
-        returnValue: _i9.Future<_i6.WordDocument>.value(_FakeWordDocument_4(
+        returnValue: _i10.Future<_i7.WordDocument>.value(_FakeWordDocument_5(
           this,
           Invocation.method(
             #fetchWordById,
@@ -460,17 +514,17 @@ class MockWordRepository extends _i1.Mock implements _i13.WordRepository {
           ),
         )),
         returnValueForMissingStub:
-            _i9.Future<_i6.WordDocument>.value(_FakeWordDocument_4(
+            _i10.Future<_i7.WordDocument>.value(_FakeWordDocument_5(
           this,
           Invocation.method(
             #fetchWordById,
             [wordId],
           ),
         )),
-      ) as _i9.Future<_i6.WordDocument>);
+      ) as _i10.Future<_i7.WordDocument>);
 
   @override
-  _i9.Future<String?> findWordId(
+  _i10.Future<String?> findWordId(
     String? word,
     String? wordReading,
   ) =>
@@ -482,12 +536,12 @@ class MockWordRepository extends _i1.Mock implements _i13.WordRepository {
             wordReading,
           ],
         ),
-        returnValue: _i9.Future<String?>.value(),
-        returnValueForMissingStub: _i9.Future<String?>.value(),
-      ) as _i9.Future<String?>);
+        returnValue: _i10.Future<String?>.value(),
+        returnValueForMissingStub: _i10.Future<String?>.value(),
+      ) as _i10.Future<String?>);
 
   @override
-  _i9.Future<_i7.WordListState> fetchWordListStateByInitial(
+  _i10.Future<_i8.WordListState> fetchWordListStateByInitial(
     String? initial,
     String? currentUserId,
     List<String>? mutedUserIdList,
@@ -503,7 +557,7 @@ class MockWordRepository extends _i1.Mock implements _i13.WordRepository {
             documentSnapshot,
           ],
         ),
-        returnValue: _i9.Future<_i7.WordListState>.value(_FakeWordListState_5(
+        returnValue: _i10.Future<_i8.WordListState>.value(_FakeWordListState_6(
           this,
           Invocation.method(
             #fetchWordListStateByInitial,
@@ -516,7 +570,7 @@ class MockWordRepository extends _i1.Mock implements _i13.WordRepository {
           ),
         )),
         returnValueForMissingStub:
-            _i9.Future<_i7.WordListState>.value(_FakeWordListState_5(
+            _i10.Future<_i8.WordListState>.value(_FakeWordListState_6(
           this,
           Invocation.method(
             #fetchWordListStateByInitial,
@@ -528,10 +582,10 @@ class MockWordRepository extends _i1.Mock implements _i13.WordRepository {
             ],
           ),
         )),
-      ) as _i9.Future<_i7.WordListState>);
+      ) as _i10.Future<_i8.WordListState>);
 
   @override
-  _i9.Future<_i7.WordListState> fetchWordListStateBySearchWord(
+  _i10.Future<_i8.WordListState> fetchWordListStateBySearchWord(
     String? searchWord,
     String? currentUserId,
     List<String>? mutedUserIdList,
@@ -547,7 +601,7 @@ class MockWordRepository extends _i1.Mock implements _i13.WordRepository {
             documentSnapshot,
           ],
         ),
-        returnValue: _i9.Future<_i7.WordListState>.value(_FakeWordListState_5(
+        returnValue: _i10.Future<_i8.WordListState>.value(_FakeWordListState_6(
           this,
           Invocation.method(
             #fetchWordListStateBySearchWord,
@@ -560,7 +614,7 @@ class MockWordRepository extends _i1.Mock implements _i13.WordRepository {
           ),
         )),
         returnValueForMissingStub:
-            _i9.Future<_i7.WordListState>.value(_FakeWordListState_5(
+            _i10.Future<_i8.WordListState>.value(_FakeWordListState_6(
           this,
           Invocation.method(
             #fetchWordListStateBySearchWord,
@@ -572,10 +626,10 @@ class MockWordRepository extends _i1.Mock implements _i13.WordRepository {
             ],
           ),
         )),
-      ) as _i9.Future<_i7.WordListState>);
+      ) as _i10.Future<_i8.WordListState>);
 
   @override
-  _i9.Future<int> fetchPostedDefinitionCount(
+  _i10.Future<int> fetchPostedDefinitionCount(
     String? wordId,
     String? currentUserId,
     List<String>? mutedUserIdList,
@@ -589,20 +643,20 @@ class MockWordRepository extends _i1.Mock implements _i13.WordRepository {
             mutedUserIdList,
           ],
         ),
-        returnValue: _i9.Future<int>.value(0),
-        returnValueForMissingStub: _i9.Future<int>.value(0),
-      ) as _i9.Future<int>);
+        returnValue: _i10.Future<int>.value(0),
+        returnValueForMissingStub: _i10.Future<int>.value(0),
+      ) as _i10.Future<int>);
 }
 
 /// A class which mocks [Listener].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockListener extends _i1.Mock
-    implements _i14.Listener<_i15.AsyncValue<_i16.Definition>> {
+    implements _i15.Listener<_i16.AsyncValue<_i17.Definition>> {
   @override
   void call(
-    _i15.AsyncValue<_i16.Definition>? previous,
-    _i15.AsyncValue<_i16.Definition>? next,
+    _i16.AsyncValue<_i17.Definition>? previous,
+    _i16.AsyncValue<_i17.Definition>? next,
   ) =>
       super.noSuchMethod(
         Invocation.method(

--- a/test/feature/user_profile/application/user_follow_service_test.mocks.dart
+++ b/test/feature/user_profile/application/user_follow_service_test.mocks.dart
@@ -179,51 +179,26 @@ class MockUserFollowRepository extends _i1.Mock
       ) as _i6.Future<List<String>>);
 
   @override
-  _i6.Future<_i4.UserIdListState> fetchFollowingIdListFirst(String? userId) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #fetchFollowingIdListFirst,
-          [userId],
-        ),
-        returnValue:
-            _i6.Future<_i4.UserIdListState>.value(_FakeUserIdListState_2(
-          this,
-          Invocation.method(
-            #fetchFollowingIdListFirst,
-            [userId],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i6.Future<_i4.UserIdListState>.value(_FakeUserIdListState_2(
-          this,
-          Invocation.method(
-            #fetchFollowingIdListFirst,
-            [userId],
-          ),
-        )),
-      ) as _i6.Future<_i4.UserIdListState>);
-
-  @override
-  _i6.Future<_i4.UserIdListState> fetchFollowingIdListMore(
+  _i6.Future<_i4.UserIdListState> fetchFollowingIdList(
     String? userId,
-    _i2.QueryDocumentSnapshot<Object?>? lastReadQueryDocumentSnapshot,
+    _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchFollowingIdListMore,
+          #fetchFollowingIdList,
           [
             userId,
-            lastReadQueryDocumentSnapshot,
+            lastDocument,
           ],
         ),
         returnValue:
             _i6.Future<_i4.UserIdListState>.value(_FakeUserIdListState_2(
           this,
           Invocation.method(
-            #fetchFollowingIdListMore,
+            #fetchFollowingIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),
@@ -231,61 +206,36 @@ class MockUserFollowRepository extends _i1.Mock
             _i6.Future<_i4.UserIdListState>.value(_FakeUserIdListState_2(
           this,
           Invocation.method(
-            #fetchFollowingIdListMore,
+            #fetchFollowingIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),
       ) as _i6.Future<_i4.UserIdListState>);
 
   @override
-  _i6.Future<_i4.UserIdListState> fetchFollowerIdListFirst(String? userId) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #fetchFollowerIdListFirst,
-          [userId],
-        ),
-        returnValue:
-            _i6.Future<_i4.UserIdListState>.value(_FakeUserIdListState_2(
-          this,
-          Invocation.method(
-            #fetchFollowerIdListFirst,
-            [userId],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i6.Future<_i4.UserIdListState>.value(_FakeUserIdListState_2(
-          this,
-          Invocation.method(
-            #fetchFollowerIdListFirst,
-            [userId],
-          ),
-        )),
-      ) as _i6.Future<_i4.UserIdListState>);
-
-  @override
-  _i6.Future<_i4.UserIdListState> fetchFollowerIdListMore(
+  _i6.Future<_i4.UserIdListState> fetchFollowerIdList(
     String? userId,
-    _i2.QueryDocumentSnapshot<Object?>? lastReadQueryDocumentSnapshot,
+    _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchFollowerIdListMore,
+          #fetchFollowerIdList,
           [
             userId,
-            lastReadQueryDocumentSnapshot,
+            lastDocument,
           ],
         ),
         returnValue:
             _i6.Future<_i4.UserIdListState>.value(_FakeUserIdListState_2(
           this,
           Invocation.method(
-            #fetchFollowerIdListMore,
+            #fetchFollowerIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),
@@ -293,10 +243,10 @@ class MockUserFollowRepository extends _i1.Mock
             _i6.Future<_i4.UserIdListState>.value(_FakeUserIdListState_2(
           this,
           Invocation.method(
-            #fetchFollowerIdListMore,
+            #fetchFollowerIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),

--- a/test/feature/user_profile/application/user_id_list_state_test.dart
+++ b/test/feature/user_profile/application/user_id_list_state_test.dart
@@ -47,11 +47,15 @@ void main() {
       // * Arrange
       // Mockの設定
       when(
-        mockUserFollowRepository.fetchFollowingIdListFirst(any),
+        mockUserFollowRepository.fetchFollowingIdList(any, any),
       ).thenAnswer((_) async => mockUserIdListState);
       const targetUserId = 'targetUserId';
       container.listen(
-        userIdListStateNotifierProvider(UserListType.following, targetUserId),
+        userIdListStateNotifierProvider(
+          UserListType.following,
+          targetUserId: targetUserId,
+          definitionId: null,
+        ),
         listener,
         fireImmediately: true,
       );
@@ -59,8 +63,11 @@ void main() {
 
       // * Act
       await container.read(
-        userIdListStateNotifierProvider(UserListType.following, targetUserId)
-            .future,
+        userIdListStateNotifierProvider(
+          UserListType.following,
+          targetUserId: targetUserId,
+          definitionId: null,
+        ).future,
       );
 
       // * Assert
@@ -84,8 +91,9 @@ void main() {
 
       // 想定通りにrepositoryの関数が呼ばれているか検証
       verify(
-        mockUserFollowRepository.fetchFollowingIdListFirst(
+        mockUserFollowRepository.fetchFollowingIdList(
           targetUserId,
+          null,
         ),
       ).called(1);
     });
@@ -94,12 +102,16 @@ void main() {
       // * Arrange
       // Mockの設定
       when(
-        mockUserFollowRepository.fetchFollowerIdListFirst(any),
+        mockUserFollowRepository.fetchFollowerIdList(any, any),
       ).thenAnswer((_) async => mockUserIdListState);
 
       const targetUserId = 'targetUserId';
       container.listen(
-        userIdListStateNotifierProvider(UserListType.follower, targetUserId),
+        userIdListStateNotifierProvider(
+          UserListType.follower,
+          targetUserId: targetUserId,
+          definitionId: null,
+        ),
         listener,
         fireImmediately: true,
       );
@@ -107,8 +119,11 @@ void main() {
 
       // * Act
       await container.read(
-        userIdListStateNotifierProvider(UserListType.follower, targetUserId)
-            .future,
+        userIdListStateNotifierProvider(
+          UserListType.follower,
+          targetUserId: targetUserId,
+          definitionId: null,
+        ).future,
       );
 
       // * Assert
@@ -132,8 +147,9 @@ void main() {
 
       // 想定通りにrepositoryの関数が呼ばれているか検証
       verify(
-        mockUserFollowRepository.fetchFollowerIdListFirst(
+        mockUserFollowRepository.fetchFollowerIdList(
           targetUserId,
+          null,
         ),
       ).called(1);
     });
@@ -149,7 +165,7 @@ void main() {
         hasMore: true,
       );
       when(
-        mockUserFollowRepository.fetchFollowingIdListFirst(any),
+        mockUserFollowRepository.fetchFollowingIdList(any, null),
       ).thenAnswer((_) async => firstState);
 
       final secondState = UserIdListState(
@@ -158,12 +174,15 @@ void main() {
         hasMore: false,
       );
       when(
-        mockUserFollowRepository.fetchFollowingIdListMore(any, any),
+        mockUserFollowRepository.fetchFollowingIdList(any, firstState.lastReadQueryDocumentSnapshot),
       ).thenAnswer((_) async => secondState);
 
       const targetUserId = 'targetUserId';
-      final userIdListProvider =
-          userIdListStateNotifierProvider(UserListType.following, targetUserId);
+      final userIdListProvider = userIdListStateNotifierProvider(
+        UserListType.following,
+        targetUserId: targetUserId,
+        definitionId: null,
+      );
       container.listen(
         userIdListProvider,
         listener,
@@ -226,7 +245,7 @@ void main() {
 
       // 想定通りにrepositoryの関数が呼ばれているか検証
       verify(
-        mockUserFollowRepository.fetchFollowingIdListMore(
+        mockUserFollowRepository.fetchFollowingIdList(
           targetUserId,
           firstState.lastReadQueryDocumentSnapshot,
         ),
@@ -242,7 +261,7 @@ void main() {
         hasMore: true,
       );
       when(
-        mockUserFollowRepository.fetchFollowerIdListFirst(any),
+        mockUserFollowRepository.fetchFollowerIdList(any, null),
       ).thenAnswer((_) async => firstState);
 
       final secondState = UserIdListState(
@@ -251,12 +270,15 @@ void main() {
         hasMore: false,
       );
       when(
-        mockUserFollowRepository.fetchFollowerIdListMore(any, any),
+        mockUserFollowRepository.fetchFollowerIdList(any, firstState.lastReadQueryDocumentSnapshot),
       ).thenAnswer((_) async => secondState);
 
       const targetUserId = 'targetUserId';
-      final userIdListProvider =
-          userIdListStateNotifierProvider(UserListType.follower, targetUserId);
+      final userIdListProvider = userIdListStateNotifierProvider(
+        UserListType.follower,
+        targetUserId: targetUserId,
+        definitionId: null,
+      );
       container.listen(
         userIdListProvider,
         listener,
@@ -319,7 +341,7 @@ void main() {
 
       // 想定通りにrepositoryの関数が呼ばれているか検証
       verify(
-        mockUserFollowRepository.fetchFollowerIdListMore(
+        mockUserFollowRepository.fetchFollowerIdList(
           targetUserId,
           firstState.lastReadQueryDocumentSnapshot,
         ),
@@ -330,12 +352,13 @@ void main() {
       // * Arrange
       // Mockの設定
       when(
-        mockUserFollowRepository.fetchFollowingIdListFirst(any),
+        mockUserFollowRepository.fetchFollowingIdList(any, null),
       ).thenAnswer((_) async => mockUserIdListState.copyWith(hasMore: false));
 
       final userIdListProvider = userIdListStateNotifierProvider(
         UserListType.following,
-        'targetUserId',
+        targetUserId: 'targetUserId',
+        definitionId: null,
       );
       container.listen(
         userIdListProvider,
@@ -361,10 +384,10 @@ void main() {
       // build()以降、listenerが発火されないことを検証
       verifyNoMoreInteractions(listener);
 
-      // 想定通り、repositoryの関数が呼ばれていないか検証
-      verifyNever(
-        mockUserFollowRepository.fetchFollowingIdListMore(any, any),
-      );
+      // 想定通り、repositoryの関数が1回のみ呼ばれているか検証
+      verify(
+        mockUserFollowRepository.fetchFollowingIdList(any, any),
+      ).called(1);
     });
 
     // TODO(me): 「ローディング中の場合、何もしない」ことを検証するテスト書く
@@ -378,16 +401,17 @@ void main() {
         hasMore: true,
       );
       when(
-        mockUserFollowRepository.fetchFollowingIdListFirst(any),
+        mockUserFollowRepository.fetchFollowingIdList(any, null),
       ).thenAnswer((_) async => firstState);
       final testException = Exception('fetchFollowingIdListFirst()で例外発生！！！');
       when(
-        mockUserFollowRepository.fetchFollowingIdListMore(any, any),
+        mockUserFollowRepository.fetchFollowingIdList(any, firstState.lastReadQueryDocumentSnapshot),
       ).thenThrow(testException);
 
       final userIdListProvider = userIdListStateNotifierProvider(
         UserListType.following,
-        'targetUserId',
+        targetUserId: 'targetUserId',
+        definitionId: null,
       );
       container.listen(
         userIdListProvider,

--- a/test/feature/user_profile/application/user_id_list_state_test.dart
+++ b/test/feature/user_profile/application/user_id_list_state_test.dart
@@ -54,7 +54,7 @@ void main() {
         userIdListStateNotifierProvider(
           UserListType.following,
           targetUserId: targetUserId,
-          definitionId: null,
+          targetDefinitionId: null,
         ),
         listener,
         fireImmediately: true,
@@ -66,7 +66,7 @@ void main() {
         userIdListStateNotifierProvider(
           UserListType.following,
           targetUserId: targetUserId,
-          definitionId: null,
+          targetDefinitionId: null,
         ).future,
       );
 
@@ -110,7 +110,7 @@ void main() {
         userIdListStateNotifierProvider(
           UserListType.follower,
           targetUserId: targetUserId,
-          definitionId: null,
+          targetDefinitionId: null,
         ),
         listener,
         fireImmediately: true,
@@ -122,7 +122,7 @@ void main() {
         userIdListStateNotifierProvider(
           UserListType.follower,
           targetUserId: targetUserId,
-          definitionId: null,
+          targetDefinitionId: null,
         ).future,
       );
 
@@ -181,7 +181,7 @@ void main() {
       final userIdListProvider = userIdListStateNotifierProvider(
         UserListType.following,
         targetUserId: targetUserId,
-        definitionId: null,
+        targetDefinitionId: null,
       );
       container.listen(
         userIdListProvider,
@@ -277,7 +277,7 @@ void main() {
       final userIdListProvider = userIdListStateNotifierProvider(
         UserListType.follower,
         targetUserId: targetUserId,
-        definitionId: null,
+        targetDefinitionId: null,
       );
       container.listen(
         userIdListProvider,
@@ -358,7 +358,7 @@ void main() {
       final userIdListProvider = userIdListStateNotifierProvider(
         UserListType.following,
         targetUserId: 'targetUserId',
-        definitionId: null,
+        targetDefinitionId: null,
       );
       container.listen(
         userIdListProvider,
@@ -411,7 +411,7 @@ void main() {
       final userIdListProvider = userIdListStateNotifierProvider(
         UserListType.following,
         targetUserId: 'targetUserId',
-        definitionId: null,
+        targetDefinitionId: null,
       );
       container.listen(
         userIdListProvider,

--- a/test/feature/user_profile/application/user_id_list_state_test.mocks.dart
+++ b/test/feature/user_profile/application/user_id_list_state_test.mocks.dart
@@ -179,51 +179,26 @@ class MockUserFollowRepository extends _i1.Mock
       ) as _i6.Future<List<String>>);
 
   @override
-  _i6.Future<_i4.UserIdListState> fetchFollowingIdListFirst(String? userId) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #fetchFollowingIdListFirst,
-          [userId],
-        ),
-        returnValue:
-            _i6.Future<_i4.UserIdListState>.value(_FakeUserIdListState_2(
-          this,
-          Invocation.method(
-            #fetchFollowingIdListFirst,
-            [userId],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i6.Future<_i4.UserIdListState>.value(_FakeUserIdListState_2(
-          this,
-          Invocation.method(
-            #fetchFollowingIdListFirst,
-            [userId],
-          ),
-        )),
-      ) as _i6.Future<_i4.UserIdListState>);
-
-  @override
-  _i6.Future<_i4.UserIdListState> fetchFollowingIdListMore(
+  _i6.Future<_i4.UserIdListState> fetchFollowingIdList(
     String? userId,
-    _i2.QueryDocumentSnapshot<Object?>? lastReadQueryDocumentSnapshot,
+    _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchFollowingIdListMore,
+          #fetchFollowingIdList,
           [
             userId,
-            lastReadQueryDocumentSnapshot,
+            lastDocument,
           ],
         ),
         returnValue:
             _i6.Future<_i4.UserIdListState>.value(_FakeUserIdListState_2(
           this,
           Invocation.method(
-            #fetchFollowingIdListMore,
+            #fetchFollowingIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),
@@ -231,61 +206,36 @@ class MockUserFollowRepository extends _i1.Mock
             _i6.Future<_i4.UserIdListState>.value(_FakeUserIdListState_2(
           this,
           Invocation.method(
-            #fetchFollowingIdListMore,
+            #fetchFollowingIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),
       ) as _i6.Future<_i4.UserIdListState>);
 
   @override
-  _i6.Future<_i4.UserIdListState> fetchFollowerIdListFirst(String? userId) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #fetchFollowerIdListFirst,
-          [userId],
-        ),
-        returnValue:
-            _i6.Future<_i4.UserIdListState>.value(_FakeUserIdListState_2(
-          this,
-          Invocation.method(
-            #fetchFollowerIdListFirst,
-            [userId],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i6.Future<_i4.UserIdListState>.value(_FakeUserIdListState_2(
-          this,
-          Invocation.method(
-            #fetchFollowerIdListFirst,
-            [userId],
-          ),
-        )),
-      ) as _i6.Future<_i4.UserIdListState>);
-
-  @override
-  _i6.Future<_i4.UserIdListState> fetchFollowerIdListMore(
+  _i6.Future<_i4.UserIdListState> fetchFollowerIdList(
     String? userId,
-    _i2.QueryDocumentSnapshot<Object?>? lastReadQueryDocumentSnapshot,
+    _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchFollowerIdListMore,
+          #fetchFollowerIdList,
           [
             userId,
-            lastReadQueryDocumentSnapshot,
+            lastDocument,
           ],
         ),
         returnValue:
             _i6.Future<_i4.UserIdListState>.value(_FakeUserIdListState_2(
           this,
           Invocation.method(
-            #fetchFollowerIdListMore,
+            #fetchFollowerIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),
@@ -293,10 +243,10 @@ class MockUserFollowRepository extends _i1.Mock
             _i6.Future<_i4.UserIdListState>.value(_FakeUserIdListState_2(
           this,
           Invocation.method(
-            #fetchFollowerIdListMore,
+            #fetchFollowerIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),

--- a/test/feature/user_profile/application/user_profile_state_test.mocks.dart
+++ b/test/feature/user_profile/application/user_profile_state_test.mocks.dart
@@ -252,51 +252,26 @@ class MockUserFollowRepository extends _i1.Mock
       ) as _i7.Future<List<String>>);
 
   @override
-  _i7.Future<_i5.UserIdListState> fetchFollowingIdListFirst(String? userId) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #fetchFollowingIdListFirst,
-          [userId],
-        ),
-        returnValue:
-            _i7.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
-          this,
-          Invocation.method(
-            #fetchFollowingIdListFirst,
-            [userId],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i7.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
-          this,
-          Invocation.method(
-            #fetchFollowingIdListFirst,
-            [userId],
-          ),
-        )),
-      ) as _i7.Future<_i5.UserIdListState>);
-
-  @override
-  _i7.Future<_i5.UserIdListState> fetchFollowingIdListMore(
+  _i7.Future<_i5.UserIdListState> fetchFollowingIdList(
     String? userId,
-    _i2.QueryDocumentSnapshot<Object?>? lastReadQueryDocumentSnapshot,
+    _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchFollowingIdListMore,
+          #fetchFollowingIdList,
           [
             userId,
-            lastReadQueryDocumentSnapshot,
+            lastDocument,
           ],
         ),
         returnValue:
             _i7.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
           this,
           Invocation.method(
-            #fetchFollowingIdListMore,
+            #fetchFollowingIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),
@@ -304,61 +279,36 @@ class MockUserFollowRepository extends _i1.Mock
             _i7.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
           this,
           Invocation.method(
-            #fetchFollowingIdListMore,
+            #fetchFollowingIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),
       ) as _i7.Future<_i5.UserIdListState>);
 
   @override
-  _i7.Future<_i5.UserIdListState> fetchFollowerIdListFirst(String? userId) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #fetchFollowerIdListFirst,
-          [userId],
-        ),
-        returnValue:
-            _i7.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
-          this,
-          Invocation.method(
-            #fetchFollowerIdListFirst,
-            [userId],
-          ),
-        )),
-        returnValueForMissingStub:
-            _i7.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
-          this,
-          Invocation.method(
-            #fetchFollowerIdListFirst,
-            [userId],
-          ),
-        )),
-      ) as _i7.Future<_i5.UserIdListState>);
-
-  @override
-  _i7.Future<_i5.UserIdListState> fetchFollowerIdListMore(
+  _i7.Future<_i5.UserIdListState> fetchFollowerIdList(
     String? userId,
-    _i2.QueryDocumentSnapshot<Object?>? lastReadQueryDocumentSnapshot,
+    _i2.QueryDocumentSnapshot<Object?>? lastDocument,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
-          #fetchFollowerIdListMore,
+          #fetchFollowerIdList,
           [
             userId,
-            lastReadQueryDocumentSnapshot,
+            lastDocument,
           ],
         ),
         returnValue:
             _i7.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
           this,
           Invocation.method(
-            #fetchFollowerIdListMore,
+            #fetchFollowerIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),
@@ -366,10 +316,10 @@ class MockUserFollowRepository extends _i1.Mock
             _i7.Future<_i5.UserIdListState>.value(_FakeUserIdListState_3(
           this,
           Invocation.method(
-            #fetchFollowerIdListMore,
+            #fetchFollowerIdList,
             [
               userId,
-              lastReadQueryDocumentSnapshot,
+              lastDocument,
             ],
           ),
         )),


### PR DESCRIPTION
# 対象Issue

- #17 

# やった事

- いいねしたユーザーの一覧表示を実装
- ユーザー一覧取得のfetchFirstとfetchMoreを統合

# やらなかった事

- UT作成

# 動作確認

- iPhone11 (実機) で検証

# その他

