### PR TITLE
強制アップデートを実装

### DIFF
--- a/lib/core/common_widget/infinity_scroll_widget.dart
+++ b/lib/core/common_widget/infinity_scroll_widget.dart
@@ -72,8 +72,8 @@ class InfinityScrollWidget extends ConsumerWidget {
           ),
         );
       },
-      error: (error, _) {
-        logger.e('$error');
+      error: (error, stackTrace) {
+        logger.e('error: $error, stackTrace: $stackTrace');
 
         // 初回読み込み時にエラーが発生し、再読み込みしている場合
         if (asyncListState.isRefreshing && !asyncListState.hasValue) {

--- a/lib/feature/definition/application/definition_for_write_notifier.dart
+++ b/lib/feature/definition/application/definition_for_write_notifier.dart
@@ -78,8 +78,8 @@ class DefinitionForWriteNotifier extends _$DefinitionForWriteNotifier {
             existingWordId,
             definitionForWrite,
           );
-    } on Exception catch (e) {
-      logger.e('定義投稿時にエラーが発生 error: $e');
+    } on Exception catch (e, stackTrace) {
+      logger.e('定義投稿時にエラーが発生 error: $e, stackTrace: $stackTrace');
       toastNotifier.showToast(
         '投稿できませんでした。もう一度お試しください。',
         causeError: true,
@@ -115,8 +115,8 @@ class DefinitionForWriteNotifier extends _$DefinitionForWriteNotifier {
             existingWordId,
             definitionForWrite,
           );
-    } on Exception catch (e) {
-      logger.e('定義編集時にエラーが発生 error: $e');
+    } on Exception catch (e, stackTrace) {
+      logger.e('定義編集時にエラーが発生 error: $e, stackTrace: $stackTrace');
       toastNotifier.showToast(
         '保存できませんでした。もう一度お試しください。',
         causeError: true,

--- a/lib/feature/definition/application/definition_id_list_state.dart
+++ b/lib/feature/definition/application/definition_id_list_state.dart
@@ -229,8 +229,8 @@ class DefinitionIdListStateNotifier extends _$DefinitionIdListStateNotifier
             isFirstFetch: isFirstFetch,
           );
       }
-    } on Exception catch (e, _) {
-      logger.e('$e');
+    } on Exception catch (e, stackTrace) {
+      logger.e('error: $e, stackTrace: $stackTrace');
       ref
           .read(toastControllerProvider.notifier)
           .showToast('読み込めませんでした。もう一度お試しください。', causeError: true);

--- a/lib/feature/definition/application/definition_service.dart
+++ b/lib/feature/definition/application/definition_service.dart
@@ -24,8 +24,8 @@ class DefinitionService extends _$DefinitionService {
 
     try {
       await _updateLikeStatus(definition);
-    } on Exception catch (e) {
-      logger.e('いいね登録もしくは解除時にエラーが発生: $e');
+    } on Exception catch (e, stackTrace) {
+      logger.e('いいね登録もしくは解除時にエラーが発生。error: $e, stackTrace: $stackTrace');
       ref
           .read(toastControllerProvider.notifier)
           .showToast('失敗しました。もう一度お試しください。', causeError: true);

--- a/lib/feature/definition/presentation/component/definition_tile.dart
+++ b/lib/feature/definition/presentation/component/definition_tile.dart
@@ -131,7 +131,7 @@ class DefinitionTile extends ConsumerWidget {
           );
         }
 
-        logger.e('definitionId [$definitionId]の取得時にエラーが発生: $error');
+        logger.e('definitionId [$definitionId]の取得時にエラーが発生: $error, stackTrace: $stackTrace');
         return Column(
           children: [
             const SizedBox(height: 16),

--- a/lib/feature/force_event/application/app_config_state.dart
+++ b/lib/feature/force_event/application/app_config_state.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:version/version.dart';
+
+import '../../user_config/application/user_config_state.dart';
+import '../repository/app_config_repository.dart';
+import '../repository/entity/app_config_document.dart';
+
+part 'app_config_state.g.dart';
+
+/// AppConfigを監視する
+@Riverpod(keepAlive: true)
+Stream<AppConfigDocument> appConfig(AppConfigRef ref) =>
+    ref.watch(appConfigRepositoryProvider).subscribeAppConfig();
+
+/// アプリのアップデートが必要かどうか
+@Riverpod(keepAlive: true)
+Future<bool> isRequiredAppUpdate(IsRequiredAppUpdateRef ref) async {
+  final appConfig = ref.watch(appConfigProvider).value;
+  final currentAppVersion = ref.watch(appVersionProvider).value;
+
+  // 少なくとも片方がロード中の場合、trueになる想定
+  if (appConfig == null || currentAppVersion == null) {
+    return false;
+  }
+
+  final parsedCurrentVersion = Version.parse(currentAppVersion);
+  late final Version parsedRequiredVersion;
+  switch (defaultTargetPlatform) {
+    case TargetPlatform.iOS:
+      parsedRequiredVersion = Version.parse(appConfig.minAppVersionForIos);
+      break;
+
+    case TargetPlatform.android:
+      parsedRequiredVersion = Version.parse(appConfig.minAppVersionForAndroid);
+      break;
+
+    case TargetPlatform.fuchsia:
+    case TargetPlatform.linux:
+    case TargetPlatform.macOS:
+    case TargetPlatform.windows:
+      throw UnsupportedError(
+        '想定外のプラットフォームです。 defaultTargetPlatform: $defaultTargetPlatform',
+      );
+  }
+
+  return parsedRequiredVersion > parsedCurrentVersion;
+}

--- a/lib/feature/force_event/application/app_config_state.g.dart
+++ b/lib/feature/force_event/application/app_config_state.g.dart
@@ -1,0 +1,44 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'app_config_state.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$appConfigHash() => r'28e72d143d5d1f2be2ef58a5851f391bb7066eba';
+
+/// AppConfigを監視する
+///
+/// Copied from [appConfig].
+@ProviderFor(appConfig)
+final appConfigProvider = StreamProvider<AppConfigDocument>.internal(
+  appConfig,
+  name: r'appConfigProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$appConfigHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef AppConfigRef = StreamProviderRef<AppConfigDocument>;
+String _$isRequiredAppUpdateHash() =>
+    r'cb5a7589b46bea1e28263e5ecd4370192b74e81e';
+
+/// アプリのアップデートが必要かどうか
+///
+/// Copied from [isRequiredAppUpdate].
+@ProviderFor(isRequiredAppUpdate)
+final isRequiredAppUpdateProvider = FutureProvider<bool>.internal(
+  isRequiredAppUpdate,
+  name: r'isRequiredAppUpdateProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$isRequiredAppUpdateHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef IsRequiredAppUpdateRef = FutureProviderRef<bool>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/force_event/presentation/overlay_force_update_dialog.dart
+++ b/lib/feature/force_event/presentation/overlay_force_update_dialog.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/common_widget/button/primary_filled_button.dart';
+
+/// 端末のバックキーや画面操作を受け付けないWidget
+///
+/// 透明のWidgetで囲い、ダイアログ表示を模している
+class OverlayForceUpdateDialog extends StatelessWidget {
+  const OverlayForceUpdateDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: () async => false,
+      child: Container(
+        height: double.infinity,
+        width: double.infinity,
+        color: Theme.of(context).colorScheme.onSurface.withOpacity(0.3),
+        child: Center(
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const SizedBox(height: 8),
+                  Text(
+                    '新たなバージョンが配信されています。\nアップデートをお願いします',
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 16),
+                  PrimaryFilledButton(
+                    onPressed: () {
+                      // TODO(me): Storeに遷移させる
+                    },
+                    text: 'アップデートする',
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/feature/force_event/repository/app_config_repository.dart
+++ b/lib/feature/force_event/repository/app_config_repository.dart
@@ -1,0 +1,29 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/common_provider/firebase_providers.dart';
+import '../../../util/constant/firestore_collections.dart';
+import 'entity/app_config_document.dart';
+
+part 'app_config_repository.g.dart';
+
+@Riverpod(keepAlive: true)
+AppConfigRepository appConfigRepository(AppConfigRepositoryRef ref) =>
+    AppConfigRepository(ref.watch(firestoreProvider));
+
+class AppConfigRepository {
+  AppConfigRepository(this.firestore);
+
+  final FirebaseFirestore firestore;
+
+  CollectionReference get _appConfigCollectionRef =>
+      firestore.collection(AppConfigCollection.collectionName);
+
+  Stream<AppConfigDocument> subscribeAppConfig() {
+    final snapshot = _appConfigCollectionRef.limit(1).snapshots();
+
+    return snapshot.map(
+      (data) => AppConfigDocument.fromFirestore(data.docs.first),
+    );
+  }
+}

--- a/lib/feature/force_event/repository/app_config_repository.g.dart
+++ b/lib/feature/force_event/repository/app_config_repository.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'app_config_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$appConfigRepositoryHash() =>
+    r'e00c73b9dd3b7b3660455581ce47a640aa76df2b';
+
+/// See also [appConfigRepository].
+@ProviderFor(appConfigRepository)
+final appConfigRepositoryProvider = Provider<AppConfigRepository>.internal(
+  appConfigRepository,
+  name: r'appConfigRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$appConfigRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef AppConfigRepositoryRef = ProviderRef<AppConfigRepository>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/force_event/repository/entity/app_config_document.dart
+++ b/lib/feature/force_event/repository/entity/app_config_document.dart
@@ -1,0 +1,24 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../../util/constant/firestore_collections.dart';
+
+part 'app_config_document.freezed.dart';
+
+@freezed
+class AppConfigDocument with _$AppConfigDocument {
+  const factory AppConfigDocument({
+    required String minAppVersionForIos,
+    required String minAppVersionForAndroid,
+  }) = _AppConfigDocument;
+
+  factory AppConfigDocument.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data()! as Map<String, dynamic>;
+    return AppConfigDocument(
+      minAppVersionForIos:
+          data[AppConfigCollection.minAppVersionForIos] as String,
+      minAppVersionForAndroid:
+          data[AppConfigCollection.minAppVersionForAndroid] as String,
+    );
+  }
+}

--- a/lib/feature/force_event/repository/entity/app_config_document.freezed.dart
+++ b/lib/feature/force_event/repository/entity/app_config_document.freezed.dart
@@ -1,0 +1,157 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'app_config_document.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$AppConfigDocument {
+  String get minAppVersionForIos => throw _privateConstructorUsedError;
+  String get minAppVersionForAndroid => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $AppConfigDocumentCopyWith<AppConfigDocument> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AppConfigDocumentCopyWith<$Res> {
+  factory $AppConfigDocumentCopyWith(
+          AppConfigDocument value, $Res Function(AppConfigDocument) then) =
+      _$AppConfigDocumentCopyWithImpl<$Res, AppConfigDocument>;
+  @useResult
+  $Res call({String minAppVersionForIos, String minAppVersionForAndroid});
+}
+
+/// @nodoc
+class _$AppConfigDocumentCopyWithImpl<$Res, $Val extends AppConfigDocument>
+    implements $AppConfigDocumentCopyWith<$Res> {
+  _$AppConfigDocumentCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? minAppVersionForIos = null,
+    Object? minAppVersionForAndroid = null,
+  }) {
+    return _then(_value.copyWith(
+      minAppVersionForIos: null == minAppVersionForIos
+          ? _value.minAppVersionForIos
+          : minAppVersionForIos // ignore: cast_nullable_to_non_nullable
+              as String,
+      minAppVersionForAndroid: null == minAppVersionForAndroid
+          ? _value.minAppVersionForAndroid
+          : minAppVersionForAndroid // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_AppConfigDocumentCopyWith<$Res>
+    implements $AppConfigDocumentCopyWith<$Res> {
+  factory _$$_AppConfigDocumentCopyWith(_$_AppConfigDocument value,
+          $Res Function(_$_AppConfigDocument) then) =
+      __$$_AppConfigDocumentCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String minAppVersionForIos, String minAppVersionForAndroid});
+}
+
+/// @nodoc
+class __$$_AppConfigDocumentCopyWithImpl<$Res>
+    extends _$AppConfigDocumentCopyWithImpl<$Res, _$_AppConfigDocument>
+    implements _$$_AppConfigDocumentCopyWith<$Res> {
+  __$$_AppConfigDocumentCopyWithImpl(
+      _$_AppConfigDocument _value, $Res Function(_$_AppConfigDocument) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? minAppVersionForIos = null,
+    Object? minAppVersionForAndroid = null,
+  }) {
+    return _then(_$_AppConfigDocument(
+      minAppVersionForIos: null == minAppVersionForIos
+          ? _value.minAppVersionForIos
+          : minAppVersionForIos // ignore: cast_nullable_to_non_nullable
+              as String,
+      minAppVersionForAndroid: null == minAppVersionForAndroid
+          ? _value.minAppVersionForAndroid
+          : minAppVersionForAndroid // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_AppConfigDocument implements _AppConfigDocument {
+  const _$_AppConfigDocument(
+      {required this.minAppVersionForIos,
+      required this.minAppVersionForAndroid});
+
+  @override
+  final String minAppVersionForIos;
+  @override
+  final String minAppVersionForAndroid;
+
+  @override
+  String toString() {
+    return 'AppConfigDocument(minAppVersionForIos: $minAppVersionForIos, minAppVersionForAndroid: $minAppVersionForAndroid)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_AppConfigDocument &&
+            (identical(other.minAppVersionForIos, minAppVersionForIos) ||
+                other.minAppVersionForIos == minAppVersionForIos) &&
+            (identical(
+                    other.minAppVersionForAndroid, minAppVersionForAndroid) ||
+                other.minAppVersionForAndroid == minAppVersionForAndroid));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, minAppVersionForIos, minAppVersionForAndroid);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_AppConfigDocumentCopyWith<_$_AppConfigDocument> get copyWith =>
+      __$$_AppConfigDocumentCopyWithImpl<_$_AppConfigDocument>(
+          this, _$identity);
+}
+
+abstract class _AppConfigDocument implements AppConfigDocument {
+  const factory _AppConfigDocument(
+      {required final String minAppVersionForIos,
+      required final String minAppVersionForAndroid}) = _$_AppConfigDocument;
+
+  @override
+  String get minAppVersionForIos;
+  @override
+  String get minAppVersionForAndroid;
+  @override
+  @JsonKey(ignore: true)
+  _$$_AppConfigDocumentCopyWith<_$_AppConfigDocument> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/feature/user_config/application/user_config_service.dart
+++ b/lib/feature/user_config/application/user_config_service.dart
@@ -53,9 +53,9 @@ class UserConfigService extends _$UserConfigService {
               targetUserId,
             );
       }
-    } on Exception catch (e) {
+    } on Exception catch (e, stackTrace) {
       final action = willMute ? 'ミュート登録' : 'ミュート解除';
-      logger.e('$action時にエラーが発生: $e');
+      logger.e('$action時にエラーが発生しました。 error: $e, stackTrace: $stackTrace');
       ref
           .read(toastControllerProvider.notifier)
           .showToast('失敗しました。もう一度お試しください。', causeError: true);

--- a/lib/feature/user_config/application/user_config_state.dart
+++ b/lib/feature/user_config/application/user_config_state.dart
@@ -15,7 +15,7 @@ Future<List<String>> mutedUserIdList(MutedUserIdListRef ref) async {
   return userProfileDoc.mutedUserIdList;
 }
 
-@riverpod
+@Riverpod(keepAlive: true)
 Future<String> appVersion(AppVersionRef ref) async {
   return ref.read(packageInfoRepositoryProvider).fetchAppVersion();
 }

--- a/lib/feature/user_config/application/user_config_state.g.dart
+++ b/lib/feature/user_config/application/user_config_state.g.dart
@@ -21,11 +21,11 @@ final mutedUserIdListProvider = FutureProvider<List<String>>.internal(
 );
 
 typedef MutedUserIdListRef = FutureProviderRef<List<String>>;
-String _$appVersionHash() => r'afa5e0b8c2d70e7438f5a4879c47a3f8cc3597be';
+String _$appVersionHash() => r'9305422aa57f020fb7cce5e07dac8610a528e41c';
 
 /// See also [appVersion].
 @ProviderFor(appVersion)
-final appVersionProvider = AutoDisposeFutureProvider<String>.internal(
+final appVersionProvider = FutureProvider<String>.internal(
   appVersion,
   name: r'appVersionProvider',
   debugGetCreateSourceHash:
@@ -34,6 +34,6 @@ final appVersionProvider = AutoDisposeFutureProvider<String>.internal(
   allTransitiveDependencies: null,
 );
 
-typedef AppVersionRef = AutoDisposeFutureProviderRef<String>;
+typedef AppVersionRef = FutureProviderRef<String>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/user_config/repository/entity/user_config_document.dart
+++ b/lib/feature/user_config/repository/entity/user_config_document.dart
@@ -22,9 +22,10 @@ class UserConfigDocument with _$UserConfigDocument {
       id: doc.id,
       appVersion: data[UserConfigsCollection.appVersion] as String,
       osVersion: data[UserConfigsCollection.osVersion] as String,
-      mutedUserIdList: ((data[UserConfigsCollection.mutedUserIdList]) as List<dynamic>)
-          .map((e) => e as String)
-          .toList(),
+      mutedUserIdList:
+          ((data[UserConfigsCollection.mutedUserIdList]) as List<dynamic>)
+              .map((e) => e as String)
+              .toList(),
       createdAt: (data[createdAtFieldName] as Timestamp).toDate(),
       updatedAt: (data[updatedAtFieldName] as Timestamp).toDate(),
     );

--- a/lib/feature/user_profile/application/user_follow_service.dart
+++ b/lib/feature/user_profile/application/user_follow_service.dart
@@ -26,8 +26,8 @@ class UserFollowService extends _$UserFollowService {
             currentUserId,
             targetUserId,
           );
-    } on Exception catch (e) {
-      logger.e('フォロー時にエラーが発生: $e');
+    } on Exception catch (e, stackTrace) {
+      logger.e('フォロー時にエラーが発生しました。error: $e, stackTrace: $stackTrace');
       ref
           .read(toastControllerProvider.notifier)
           .showToast('フォローに失敗しました', causeError: true);
@@ -53,8 +53,8 @@ class UserFollowService extends _$UserFollowService {
             currentUserId,
             targetUserId,
           );
-    } on Exception catch (e) {
-      logger.e('フォロー解除時にエラーが発生: $e');
+    } on Exception catch (e, stackTrace) {
+      logger.e('フォロー解除時にエラーが発生しました。error: $e, stackTrace: $stackTrace');
       ref.read(toastControllerProvider.notifier).showToast(
             'フォロー解除に失敗しました',
             causeError: true,

--- a/lib/feature/user_profile/application/user_id_list_state.dart
+++ b/lib/feature/user_profile/application/user_id_list_state.dart
@@ -78,8 +78,8 @@ class UserIdListStateNotifier extends _$UserIdListStateNotifier
                 lastDocument,
               );
       }
-    } on Exception catch (e, _) {
-      logger.e('$e');
+    } on Exception catch (e, stackTrace) {
+      logger.e('error: $e, stackTrace: $stackTrace');
       ref
           .read(toastControllerProvider.notifier)
           .showToast('読み込めませんでした。もう一度お試しください。', causeError: true);

--- a/lib/feature/user_profile/application/user_profile_for_write_notifier.dart
+++ b/lib/feature/user_profile/application/user_profile_for_write_notifier.dart
@@ -90,8 +90,8 @@ class UserProfileForWriteNotifier extends _$UserProfileForWriteNotifier {
           );
 
       // プロフィールを更新
-    } on Exception catch (e) {
-      logger.e('プロフィール編集時にエラーが発生 error: $e');
+    } on Exception catch (e, stackTrace) {
+      logger.e('プロフィール編集時にエラーが発生 error: $e, stackTrace: $stackTrace');
       toastNotifier.showToast(
         '保存できませんでした。もう一度お試しください。',
         causeError: true,

--- a/lib/feature/user_profile/presentation/page/following_and_follower_list/profile_tile.dart
+++ b/lib/feature/user_profile/presentation/page/following_and_follower_list/profile_tile.dart
@@ -111,7 +111,7 @@ class ProfileTile extends ConsumerWidget {
           );
         }
 
-        logger.e('userId [$targetUserId]の取得時にエラーが発生: $error');
+        logger.e('userId [$targetUserId]の取得時にエラーが発生: $error, stackTrace: $stackTrace');
         return Column(
           children: [
             const SizedBox(height: 16),

--- a/lib/feature/user_profile/presentation/page/profile/following_and_follower_count_widget.dart
+++ b/lib/feature/user_profile/presentation/page/profile/following_and_follower_count_widget.dart
@@ -85,7 +85,7 @@ class FollowingAndFollowerCountWidget extends ConsumerWidget {
         ],
       ),
       error: (error, stackTrace) {
-        logger.e('followCountの取得時にエラーが発生しました。 error: $error');
+        logger.e('followCountの取得時にエラーが発生しました。 error: $error, stackTrace: $stackTrace');
         // フォローカウントのみのエラーはユーザーへの影響が少ないため、何も表示しない
         // フォローカウント以外にもエラーが有る場合、他画面でエラーが表示される想定
         return const SizedBox.shrink();

--- a/lib/feature/user_profile/presentation/page/profile/profile_page.dart
+++ b/lib/feature/user_profile/presentation/page/profile/profile_page.dart
@@ -47,8 +47,8 @@ class ProfilePage extends ConsumerWidget {
                       );
                     },
                     loading: () => const Text(''),
-                    error: (error, _) {
-                      logger.e(error);
+                    error: (error, stackTrace) {
+                      logger.e('error: $error, stackTrace: $stackTrace');
                       return const Text('エラー');
                     },
                   ),

--- a/lib/feature/word/application/word_list_state_by_initial.dart
+++ b/lib/feature/word/application/word_list_state_by_initial.dart
@@ -33,8 +33,8 @@ class WordListStateByInitialNotifier extends _$WordListStateByInitialNotifier
             mutedUserIdList,
             lastDocument,
           );
-    } on Exception catch (e, _) {
-      logger.e('$e');
+    } on Exception catch (e, stackTrace) {
+      logger.e('$e, stackTrace: $stackTrace');
       ref
           .read(toastControllerProvider.notifier)
           .showToast('読み込めませんでした。もう一度お試しください。', causeError: true);

--- a/lib/feature/word/application/word_list_state_by_search_word.dart
+++ b/lib/feature/word/application/word_list_state_by_search_word.dart
@@ -33,8 +33,8 @@ class WordListStateBySearchWordNotifier
             mutedUserIdList,
             lastDocument,
           );
-    } on Exception catch (e, _) {
-      logger.e('$e');
+    } on Exception catch (e, stackTrace) {
+      logger.e('error: $e, stackTrace: $stackTrace');
       ref
           .read(toastControllerProvider.notifier)
           .showToast('読み込めませんでした。もう一度お試しください。', causeError: true);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,12 +8,16 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'core/common_provider/is_loading_overlay_state.dart';
+import 'core/common_widget/error_and_retry_widget.dart';
 import 'core/common_widget/loading_dialog.dart';
 import 'core/router/app_router.dart';
 import 'feature/auth/application/auth_service.dart';
 import 'feature/auth/application/auth_state.dart';
+import 'feature/force_event/application/app_config_state.dart';
+import 'feature/force_event/presentation/overlay_force_update_dialog.dart';
 import 'firebase_options/firebase_options.dart';
 import 'util/constant/theme_data.dart';
+import 'util/logger.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -84,40 +88,59 @@ class _MyAppState extends ConsumerState<MyApp> {
       theme: getThemeData(ThemeMode.light, context),
       darkTheme: getThemeData(ThemeMode.dark, context),
       builder: (context, child) {
-        final isSignedIn = ref.watch(isSignedInProvider);
-        if (isSignedIn) {
-          final async = ref.watch(authServiceProvider);
-          return async.when(
-            data: (_) {
-              return Stack(
-                children: [
-                  child!,
-                  if (ref.watch(isLoadingOverlayNotifierProvider))
-                    const OverlayLoadingWidget(),
-                ],
-              );
-            },
-            loading: () {
-              return const Scaffold(
-                body: OverlayLoadingWidget(),
-              );
-            },
-            error: (error, stack) {
-              // TODO(me): エラー画面を作成し、表示させる
-              // publicIdの重複でエラーが発生する可能性があるため、
-              // 少なくとも再試行できるボタンを表示させる
-              return Scaffold(
-                body: Center(
-                  child: Text('エラーが発生しました\n$error'),
-                ),
-              );
-            },
-          );
-        }
-        // 起動直後にisSignedInがfalseになる想定
-        return const Scaffold(
-          body: OverlayLoadingWidget(),
-        );
+        // TODO(me): asyncValue.whenがネストしているのなんとかしたい
+
+        // 強制アップデート関連の処理
+        return ref.watch(isRequiredAppUpdateProvider).when(
+              loading: () => const Scaffold(body: OverlayLoadingWidget()),
+              error: (e, s) {
+                logger.e('[asyncIsRequiredUpdate]の取得時にエラーが発生しました。'
+                    ' error: $e, stackTrace: $s');
+                return ErrorAndRetryWidget(
+                  onRetry: () => ref.invalidate(isRequiredAppUpdateProvider),
+                );
+              },
+              data: (isRequiredUpdate) {
+                if (isRequiredUpdate) {
+                  // アップデートが必要な場合
+                  return Stack(
+                    children: [
+                      child!,
+                      const OverlayForceUpdateDialog(),
+                    ],
+                  );
+                }
+
+                // アップデートが不要な場合
+                if (ref.watch(isSignedInProvider)) {
+                  final async = ref.watch(authServiceProvider);
+                  return async.when(
+                    data: (_) {
+                      return Stack(
+                        children: [
+                          child!,
+                          if (ref.watch(isLoadingOverlayNotifierProvider))
+                            const OverlayLoadingWidget(),
+                        ],
+                      );
+                    },
+                    loading: () => const Scaffold(body: OverlayLoadingWidget()),
+                    error: (error, stack) {
+                      // TODO(me): エラー画面を作成し、表示させる
+                      // publicIdの重複でエラーが発生する可能性があるため、
+                      // 少なくとも再試行できるボタンを表示させる
+                      return Scaffold(
+                        body: Center(
+                          child: Text('エラーが発生しました\n$error'),
+                        ),
+                      );
+                    },
+                  );
+                }
+                // 起動直後にisSignedInがfalseになる想定
+                return const Scaffold(body: OverlayLoadingWidget());
+              },
+            );
       },
     );
   }

--- a/lib/util/constant/firestore_collections.dart
+++ b/lib/util/constant/firestore_collections.dart
@@ -71,3 +71,11 @@ class UserFollowCountsCollection {
   static const followerCount = 'followerCount';
   static const followingCount = 'followingCount';
 }
+
+class AppConfigCollection {
+  static const collectionName = 'AppConfig';
+
+  // Field
+  static const minAppVersionForIos = 'minAppVersionForIos';
+  static const minAppVersionForAndroid = 'minAppVersionForAndroid';
+}

--- a/lib/util/extension/string_extension.dart
+++ b/lib/util/extension/string_extension.dart
@@ -31,4 +31,6 @@ extension StringExtension on String {
     // カタカナからひらがなに変換
     return String.fromCharCode(code - 0x0060);
   }
+
+  
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1218,6 +1218,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  version:
+    dependency: "direct main"
+    description:
+      name: version
+      sha256: "3d4140128e6ea10d83da32fef2fa4003fccbf6852217bb854845802f04191f94"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   riverpod_annotation: ^2.2.0
   roggle: ^0.4.2+1
   shimmer: ^3.0.0
+  version: ^3.0.2
 
   # Firebase関連
   cloud_firestore: ^4.9.2


### PR DESCRIPTION
# 対象Issue

- #43 

# やった事

- 強制アップデートを実装
- エラー時のログ出力でstackTraceも出力するよう修正

# やらなかった事

# 動作確認

- iPhone11 (実機) で実施

# その他



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - アプリに検索機能を追加しました。
  - アプリの更新が必要かどうかを判断する機能を追加しました。
  - 強制アップデートのダイアログを表示する新しいウィジェットを追加しました。

- **バグ修正**
  - エラーハンドリングを改善し、スタックトレースを含むようにしました。

- **ドキュメント**
  - エラーログにスタックトレースを含めるための変更を行いました。

- **リファクタ**
  - エラーハンドリングのコードを改善し、より詳細な情報を提供するようにしました。

- **スタイル**
  - コードの可読性を向上させるためのフォーマット変更を行いました。

- **テスト**
  - 特に変更はありません。

- **チョア**
  - 内部コードの生成やリントルールの無視に関する変更を行いました。

- **リバート**
  - 特に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->