### PR TITLE
メンテナンス時の挙動を実装

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -891,6 +891,8 @@ PODS:
     - FMDB (>= 2.7.5)
   - Toast (4.0.0)
   - TOCropViewController (2.6.1)
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
@@ -907,6 +909,7 @@ DEPENDENCIES:
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
   trunk:
@@ -969,6 +972,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   sqflite:
     :path: ".symlinks/plugins/sqflite/ios"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   abseil: 926fb7a82dc6d2b8e1f2ed7f3a718bce691d1e46
@@ -1014,6 +1019,7 @@ SPEC CHECKSUMS:
   sqflite: 31f7eba61e3074736dff8807a9b41581e4f7f15a
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
+  url_launcher_ios: 68d46cc9766d0c41dbdc884310529557e3cd7a86
 
 PODFILE CHECKSUM: 70d9d25280d0dd177a5f637cdb0f0b0b12c6a189
 

--- a/lib/core/common_provider/launch_url.dart
+++ b/lib/core/common_provider/launch_url.dart
@@ -1,0 +1,19 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../util/logger.dart';
+import 'toast_controller.dart';
+
+part 'launch_url.g.dart';
+
+// [launchUrl] との重複を避けるために、[launchURL] と命名
+@riverpod
+Future<void> launchURL(LaunchURLRef ref, String url) async {
+  final uri = Uri.parse(url);
+  if (!await launchUrl(uri)) {
+    logger.e('$uri を開けませんでした。');
+    ref
+        .read(toastControllerProvider.notifier)
+        .showToast('ページを開けませんでした。もう一度お試しください。');
+  }
+}

--- a/lib/core/common_provider/launch_url.g.dart
+++ b/lib/core/common_provider/launch_url.g.dart
@@ -1,0 +1,157 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'launch_url.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$launchURLHash() => r'5bb5ab81d6ef3c799c2e18651b9f99d2bd2dae1f';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+/// See also [launchURL].
+@ProviderFor(launchURL)
+const launchURLProvider = LaunchURLFamily();
+
+/// See also [launchURL].
+class LaunchURLFamily extends Family<AsyncValue<void>> {
+  /// See also [launchURL].
+  const LaunchURLFamily();
+
+  /// See also [launchURL].
+  LaunchURLProvider call(
+    String url,
+  ) {
+    return LaunchURLProvider(
+      url,
+    );
+  }
+
+  @override
+  LaunchURLProvider getProviderOverride(
+    covariant LaunchURLProvider provider,
+  ) {
+    return call(
+      provider.url,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'launchURLProvider';
+}
+
+/// See also [launchURL].
+class LaunchURLProvider extends AutoDisposeFutureProvider<void> {
+  /// See also [launchURL].
+  LaunchURLProvider(
+    String url,
+  ) : this._internal(
+          (ref) => launchURL(
+            ref as LaunchURLRef,
+            url,
+          ),
+          from: launchURLProvider,
+          name: r'launchURLProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$launchURLHash,
+          dependencies: LaunchURLFamily._dependencies,
+          allTransitiveDependencies: LaunchURLFamily._allTransitiveDependencies,
+          url: url,
+        );
+
+  LaunchURLProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.url,
+  }) : super.internal();
+
+  final String url;
+
+  @override
+  Override overrideWith(
+    FutureOr<void> Function(LaunchURLRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: LaunchURLProvider._internal(
+        (ref) => create(ref as LaunchURLRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        url: url,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeFutureProviderElement<void> createElement() {
+    return _LaunchURLProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is LaunchURLProvider && other.url == url;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, url.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin LaunchURLRef on AutoDisposeFutureProviderRef<void> {
+  /// The parameter `url` of this provider.
+  String get url;
+}
+
+class _LaunchURLProviderElement extends AutoDisposeFutureProviderElement<void>
+    with LaunchURLRef {
+  _LaunchURLProviderElement(super.provider);
+
+  @override
+  String get url => (origin as LaunchURLProvider).url;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/definition/application/definition_for_write_notifier.g.dart
+++ b/lib/feature/definition/application/definition_for_write_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'definition_for_write_notifier.dart';
 // **************************************************************************
 
 String _$definitionForWriteNotifierHash() =>
-    r'71d956344313456d1a48ff56cc1d5d13855f2027';
+    r'78a03db2f2422ce73a9382763ee8652845363f59';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/feature/definition/application/definition_id_list_state.g.dart
+++ b/lib/feature/definition/application/definition_id_list_state.g.dart
@@ -7,7 +7,7 @@ part of 'definition_id_list_state.dart';
 // **************************************************************************
 
 String _$definitionIdListStateNotifierHash() =>
-    r'd6c59a0abe7c4097e4c73addfcf9ef7cebaebbf8';
+    r'0f4c15e758f7fca4a678cd63de1c4ecfa9544bef';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/feature/definition/application/definition_service.g.dart
+++ b/lib/feature/definition/application/definition_service.g.dart
@@ -6,7 +6,7 @@ part of 'definition_service.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$definitionServiceHash() => r'f36f5824866c97705bd5dbf5645e5ad722d14578';
+String _$definitionServiceHash() => r'41fa467cb57464a4d661366ae3906324520aea7b';
 
 /// See also [DefinitionService].
 @ProviderFor(DefinitionService)

--- a/lib/feature/force_event/application/app_config_state.dart
+++ b/lib/feature/force_event/application/app_config_state.dart
@@ -3,6 +3,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:version/version.dart';
 
 import '../../user_config/application/user_config_state.dart';
+import '../domain/app_maintenance.dart';
 import '../repository/app_config_repository.dart';
 import '../repository/entity/app_config_document.dart';
 
@@ -45,4 +46,20 @@ Future<bool> isRequiredAppUpdate(IsRequiredAppUpdateRef ref) async {
   }
 
   return parsedRequiredVersion > parsedCurrentVersion;
+}
+
+/// アプリのメンテナンス情報を保持する
+///
+/// [AppMaintenance]のinMaintenanceがfalse,
+/// もしくは nullの場合はメンテナンス中でない
+@Riverpod(keepAlive: true)
+AppMaintenance? appMaintenance(AppMaintenanceRef ref) {
+  final appConfig = ref.watch(appConfigProvider).value;
+
+  // ロード中の場合、nullを返す
+  if (appConfig == null) {
+    return null;
+  }
+
+  return appConfig.toAppMaintenance();
 }

--- a/lib/feature/force_event/application/app_config_state.g.dart
+++ b/lib/feature/force_event/application/app_config_state.g.dart
@@ -23,7 +23,7 @@ final appConfigProvider = StreamProvider<AppConfigDocument>.internal(
 
 typedef AppConfigRef = StreamProviderRef<AppConfigDocument>;
 String _$isRequiredAppUpdateHash() =>
-    r'cb5a7589b46bea1e28263e5ecd4370192b74e81e';
+    r'ad6191ba4d20745d89938655fbaa4a643dc5e5d9';
 
 /// アプリのアップデートが必要かどうか
 ///
@@ -40,5 +40,25 @@ final isRequiredAppUpdateProvider = FutureProvider<bool>.internal(
 );
 
 typedef IsRequiredAppUpdateRef = FutureProviderRef<bool>;
+String _$appMaintenanceHash() => r'235fe44d1299e9bd787d26b51f397f095bb3acf6';
+
+/// アプリのメンテナンス情報を保持する
+///
+/// [AppMaintenance]のinMaintenanceがfalse,
+/// もしくは nullの場合はメンテナンス中でない
+///
+/// Copied from [appMaintenance].
+@ProviderFor(appMaintenance)
+final appMaintenanceProvider = Provider<AppMaintenance?>.internal(
+  appMaintenance,
+  name: r'appMaintenanceProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$appMaintenanceHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef AppMaintenanceRef = ProviderRef<AppMaintenance?>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/force_event/domain/app_maintenance.dart
+++ b/lib/feature/force_event/domain/app_maintenance.dart
@@ -1,0 +1,11 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'app_maintenance.freezed.dart';
+
+@freezed
+class AppMaintenance with _$AppMaintenance {
+  const factory AppMaintenance({
+    required bool inMaintenance,
+    required String scheduledEndTime,
+  }) = _AppMaintenance;
+}

--- a/lib/feature/force_event/domain/app_maintenance.freezed.dart
+++ b/lib/feature/force_event/domain/app_maintenance.freezed.dart
@@ -1,0 +1,153 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'app_maintenance.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$AppMaintenance {
+  bool get inMaintenance => throw _privateConstructorUsedError;
+  String get scheduledEndTime => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $AppMaintenanceCopyWith<AppMaintenance> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AppMaintenanceCopyWith<$Res> {
+  factory $AppMaintenanceCopyWith(
+          AppMaintenance value, $Res Function(AppMaintenance) then) =
+      _$AppMaintenanceCopyWithImpl<$Res, AppMaintenance>;
+  @useResult
+  $Res call({bool inMaintenance, String scheduledEndTime});
+}
+
+/// @nodoc
+class _$AppMaintenanceCopyWithImpl<$Res, $Val extends AppMaintenance>
+    implements $AppMaintenanceCopyWith<$Res> {
+  _$AppMaintenanceCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? inMaintenance = null,
+    Object? scheduledEndTime = null,
+  }) {
+    return _then(_value.copyWith(
+      inMaintenance: null == inMaintenance
+          ? _value.inMaintenance
+          : inMaintenance // ignore: cast_nullable_to_non_nullable
+              as bool,
+      scheduledEndTime: null == scheduledEndTime
+          ? _value.scheduledEndTime
+          : scheduledEndTime // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_AppMaintenanceCopyWith<$Res>
+    implements $AppMaintenanceCopyWith<$Res> {
+  factory _$$_AppMaintenanceCopyWith(
+          _$_AppMaintenance value, $Res Function(_$_AppMaintenance) then) =
+      __$$_AppMaintenanceCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({bool inMaintenance, String scheduledEndTime});
+}
+
+/// @nodoc
+class __$$_AppMaintenanceCopyWithImpl<$Res>
+    extends _$AppMaintenanceCopyWithImpl<$Res, _$_AppMaintenance>
+    implements _$$_AppMaintenanceCopyWith<$Res> {
+  __$$_AppMaintenanceCopyWithImpl(
+      _$_AppMaintenance _value, $Res Function(_$_AppMaintenance) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? inMaintenance = null,
+    Object? scheduledEndTime = null,
+  }) {
+    return _then(_$_AppMaintenance(
+      inMaintenance: null == inMaintenance
+          ? _value.inMaintenance
+          : inMaintenance // ignore: cast_nullable_to_non_nullable
+              as bool,
+      scheduledEndTime: null == scheduledEndTime
+          ? _value.scheduledEndTime
+          : scheduledEndTime // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_AppMaintenance implements _AppMaintenance {
+  const _$_AppMaintenance(
+      {required this.inMaintenance, required this.scheduledEndTime});
+
+  @override
+  final bool inMaintenance;
+  @override
+  final String scheduledEndTime;
+
+  @override
+  String toString() {
+    return 'AppMaintenance(inMaintenance: $inMaintenance, scheduledEndTime: $scheduledEndTime)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_AppMaintenance &&
+            (identical(other.inMaintenance, inMaintenance) ||
+                other.inMaintenance == inMaintenance) &&
+            (identical(other.scheduledEndTime, scheduledEndTime) ||
+                other.scheduledEndTime == scheduledEndTime));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, inMaintenance, scheduledEndTime);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_AppMaintenanceCopyWith<_$_AppMaintenance> get copyWith =>
+      __$$_AppMaintenanceCopyWithImpl<_$_AppMaintenance>(this, _$identity);
+}
+
+abstract class _AppMaintenance implements AppMaintenance {
+  const factory _AppMaintenance(
+      {required final bool inMaintenance,
+      required final String scheduledEndTime}) = _$_AppMaintenance;
+
+  @override
+  bool get inMaintenance;
+  @override
+  String get scheduledEndTime;
+  @override
+  @JsonKey(ignore: true)
+  _$$_AppMaintenanceCopyWith<_$_AppMaintenance> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/feature/force_event/presentation/overlay_in_maintenance_dialog.dart
+++ b/lib/feature/force_event/presentation/overlay_in_maintenance_dialog.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/common_widget/button/primary_filled_button.dart';
+import '../domain/app_maintenance.dart';
+
+/// 端末のバックキーや画面操作を受け付けないWidget
+///
+/// 透明のWidgetで囲い、ダイアログ表示を模している
+class OverlayInMaintenanceDialog extends StatelessWidget {
+  const OverlayInMaintenanceDialog({super.key, required this.appMaintenance});
+
+  final AppMaintenance appMaintenance;
+
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: () async => false,
+      child: Container(
+        height: double.infinity,
+        width: double.infinity,
+        color: Theme.of(context).colorScheme.onSurface.withOpacity(0.3),
+        child: Center(
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const SizedBox(height: 8),
+                  Text(
+                    '🤖現在メンテナンス中です🤖'
+                    '\n終了予定は${appMaintenance.scheduledEndTime}です。',
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'ご不便をおかけし申し訳ございません🙇‍♂\n'
+                    '詳しい情報は下記からご確認いただけます。',
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 16),
+                  PrimaryFilledButton(
+                    onPressed: () {
+                      // TODO(me): 更新情報が記載されているWebページ（Notion）へ遷移する
+                    },
+                    text: '最新情報を確認する',
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/feature/force_event/presentation/overlay_in_maintenance_dialog.dart
+++ b/lib/feature/force_event/presentation/overlay_in_maintenance_dialog.dart
@@ -1,18 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/common_provider/launch_url.dart';
 import '../../../core/common_widget/button/primary_filled_button.dart';
+import '../../../util/constant/url.dart';
 import '../domain/app_maintenance.dart';
 
 /// 端末のバックキーや画面操作を受け付けないWidget
 ///
 /// 透明のWidgetで囲い、ダイアログ表示を模している
-class OverlayInMaintenanceDialog extends StatelessWidget {
+class OverlayInMaintenanceDialog extends ConsumerWidget {
   const OverlayInMaintenanceDialog({super.key, required this.appMaintenance});
 
   final AppMaintenance appMaintenance;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return WillPopScope(
       onWillPop: () async => false,
       child: Container(
@@ -47,7 +50,7 @@ class OverlayInMaintenanceDialog extends StatelessWidget {
                   const SizedBox(height: 16),
                   PrimaryFilledButton(
                     onPressed: () {
-                      // TODO(me): 更新情報が記載されているWebページ（Notion）へ遷移する
+                      ref.read(launchURLProvider(latestInformationPage));
                     },
                     text: '最新情報を確認する',
                   ),

--- a/lib/feature/force_event/repository/entity/app_config_document.dart
+++ b/lib/feature/force_event/repository/entity/app_config_document.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import '../../../../util/constant/firestore_collections.dart';
+import '../../domain/app_maintenance.dart';
 
 part 'app_config_document.freezed.dart';
 
@@ -10,15 +11,43 @@ class AppConfigDocument with _$AppConfigDocument {
   const factory AppConfigDocument({
     required String minAppVersionForIos,
     required String minAppVersionForAndroid,
+    required Map<String, Map<String, Object>> maintenanceMap,
   }) = _AppConfigDocument;
+  const AppConfigDocument._();
 
   factory AppConfigDocument.fromFirestore(DocumentSnapshot doc) {
     final data = doc.data()! as Map<String, dynamic>;
+
+    // maintenanceMapを生成
+    // 関数として抽出したいが、factoryメソットから関数を呼び出せないと怒られるため断念
+    final rawMaintenanceMap =
+        data[AppConfigCollection.maintenanceMap] as Map<String, dynamic>;
+    final maintenanceMap = {
+      AppConfigCollection.maintenanceMap: {
+        AppConfigCollection.inMaintenance:
+            rawMaintenanceMap[AppConfigCollection.inMaintenance] as bool,
+        AppConfigCollection.scheduledEndTime:
+            rawMaintenanceMap[AppConfigCollection.scheduledEndTime] as String,
+      },
+    };
+
     return AppConfigDocument(
       minAppVersionForIos:
           data[AppConfigCollection.minAppVersionForIos] as String,
       minAppVersionForAndroid:
           data[AppConfigCollection.minAppVersionForAndroid] as String,
+      maintenanceMap: maintenanceMap,
+    );
+  }
+
+  AppMaintenance toAppMaintenance() {
+    final maintenanceMap =
+        this.maintenanceMap[AppConfigCollection.maintenanceMap]!;
+
+    return AppMaintenance(
+      inMaintenance: maintenanceMap[AppConfigCollection.inMaintenance]! as bool,
+      scheduledEndTime:
+          maintenanceMap[AppConfigCollection.scheduledEndTime]! as String,
     );
   }
 }

--- a/lib/feature/force_event/repository/entity/app_config_document.freezed.dart
+++ b/lib/feature/force_event/repository/entity/app_config_document.freezed.dart
@@ -18,6 +18,8 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$AppConfigDocument {
   String get minAppVersionForIos => throw _privateConstructorUsedError;
   String get minAppVersionForAndroid => throw _privateConstructorUsedError;
+  Map<String, Map<String, Object>> get maintenanceMap =>
+      throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $AppConfigDocumentCopyWith<AppConfigDocument> get copyWith =>
@@ -30,7 +32,10 @@ abstract class $AppConfigDocumentCopyWith<$Res> {
           AppConfigDocument value, $Res Function(AppConfigDocument) then) =
       _$AppConfigDocumentCopyWithImpl<$Res, AppConfigDocument>;
   @useResult
-  $Res call({String minAppVersionForIos, String minAppVersionForAndroid});
+  $Res call(
+      {String minAppVersionForIos,
+      String minAppVersionForAndroid,
+      Map<String, Map<String, Object>> maintenanceMap});
 }
 
 /// @nodoc
@@ -48,6 +53,7 @@ class _$AppConfigDocumentCopyWithImpl<$Res, $Val extends AppConfigDocument>
   $Res call({
     Object? minAppVersionForIos = null,
     Object? minAppVersionForAndroid = null,
+    Object? maintenanceMap = null,
   }) {
     return _then(_value.copyWith(
       minAppVersionForIos: null == minAppVersionForIos
@@ -58,6 +64,10 @@ class _$AppConfigDocumentCopyWithImpl<$Res, $Val extends AppConfigDocument>
           ? _value.minAppVersionForAndroid
           : minAppVersionForAndroid // ignore: cast_nullable_to_non_nullable
               as String,
+      maintenanceMap: null == maintenanceMap
+          ? _value.maintenanceMap
+          : maintenanceMap // ignore: cast_nullable_to_non_nullable
+              as Map<String, Map<String, Object>>,
     ) as $Val);
   }
 }
@@ -70,7 +80,10 @@ abstract class _$$_AppConfigDocumentCopyWith<$Res>
       __$$_AppConfigDocumentCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String minAppVersionForIos, String minAppVersionForAndroid});
+  $Res call(
+      {String minAppVersionForIos,
+      String minAppVersionForAndroid,
+      Map<String, Map<String, Object>> maintenanceMap});
 }
 
 /// @nodoc
@@ -86,6 +99,7 @@ class __$$_AppConfigDocumentCopyWithImpl<$Res>
   $Res call({
     Object? minAppVersionForIos = null,
     Object? minAppVersionForAndroid = null,
+    Object? maintenanceMap = null,
   }) {
     return _then(_$_AppConfigDocument(
       minAppVersionForIos: null == minAppVersionForIos
@@ -96,25 +110,39 @@ class __$$_AppConfigDocumentCopyWithImpl<$Res>
           ? _value.minAppVersionForAndroid
           : minAppVersionForAndroid // ignore: cast_nullable_to_non_nullable
               as String,
+      maintenanceMap: null == maintenanceMap
+          ? _value._maintenanceMap
+          : maintenanceMap // ignore: cast_nullable_to_non_nullable
+              as Map<String, Map<String, Object>>,
     ));
   }
 }
 
 /// @nodoc
 
-class _$_AppConfigDocument implements _AppConfigDocument {
+class _$_AppConfigDocument extends _AppConfigDocument {
   const _$_AppConfigDocument(
       {required this.minAppVersionForIos,
-      required this.minAppVersionForAndroid});
+      required this.minAppVersionForAndroid,
+      required final Map<String, Map<String, Object>> maintenanceMap})
+      : _maintenanceMap = maintenanceMap,
+        super._();
 
   @override
   final String minAppVersionForIos;
   @override
   final String minAppVersionForAndroid;
+  final Map<String, Map<String, Object>> _maintenanceMap;
+  @override
+  Map<String, Map<String, Object>> get maintenanceMap {
+    if (_maintenanceMap is EqualUnmodifiableMapView) return _maintenanceMap;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_maintenanceMap);
+  }
 
   @override
   String toString() {
-    return 'AppConfigDocument(minAppVersionForIos: $minAppVersionForIos, minAppVersionForAndroid: $minAppVersionForAndroid)';
+    return 'AppConfigDocument(minAppVersionForIos: $minAppVersionForIos, minAppVersionForAndroid: $minAppVersionForAndroid, maintenanceMap: $maintenanceMap)';
   }
 
   @override
@@ -126,12 +154,17 @@ class _$_AppConfigDocument implements _AppConfigDocument {
                 other.minAppVersionForIos == minAppVersionForIos) &&
             (identical(
                     other.minAppVersionForAndroid, minAppVersionForAndroid) ||
-                other.minAppVersionForAndroid == minAppVersionForAndroid));
+                other.minAppVersionForAndroid == minAppVersionForAndroid) &&
+            const DeepCollectionEquality()
+                .equals(other._maintenanceMap, _maintenanceMap));
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, minAppVersionForIos, minAppVersionForAndroid);
+  int get hashCode => Object.hash(
+      runtimeType,
+      minAppVersionForIos,
+      minAppVersionForAndroid,
+      const DeepCollectionEquality().hash(_maintenanceMap));
 
   @JsonKey(ignore: true)
   @override
@@ -141,15 +174,20 @@ class _$_AppConfigDocument implements _AppConfigDocument {
           this, _$identity);
 }
 
-abstract class _AppConfigDocument implements AppConfigDocument {
+abstract class _AppConfigDocument extends AppConfigDocument {
   const factory _AppConfigDocument(
-      {required final String minAppVersionForIos,
-      required final String minAppVersionForAndroid}) = _$_AppConfigDocument;
+          {required final String minAppVersionForIos,
+          required final String minAppVersionForAndroid,
+          required final Map<String, Map<String, Object>> maintenanceMap}) =
+      _$_AppConfigDocument;
+  const _AppConfigDocument._() : super._();
 
   @override
   String get minAppVersionForIos;
   @override
   String get minAppVersionForAndroid;
+  @override
+  Map<String, Map<String, Object>> get maintenanceMap;
   @override
   @JsonKey(ignore: true)
   _$$_AppConfigDocumentCopyWith<_$_AppConfigDocument> get copyWith =>

--- a/lib/feature/user_config/application/user_config_service.g.dart
+++ b/lib/feature/user_config/application/user_config_service.g.dart
@@ -6,7 +6,7 @@ part of 'user_config_service.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$userConfigServiceHash() => r'93dd1e1b93b2d6ddbf081fa4e4868c2396583a54';
+String _$userConfigServiceHash() => r'15e4592b5af1efdbe5b87e2ce89bad3f2971a56d';
 
 /// See also [UserConfigService].
 @ProviderFor(UserConfigService)

--- a/lib/feature/user_profile/application/user_follow_service.g.dart
+++ b/lib/feature/user_profile/application/user_follow_service.g.dart
@@ -6,7 +6,7 @@ part of 'user_follow_service.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$userFollowServiceHash() => r'9db15e4b93708016a577c7b66a76324721a6eb91';
+String _$userFollowServiceHash() => r'51000e3b0fbfd18d07f6a84d567dc69067c8f982';
 
 /// See also [UserFollowService].
 @ProviderFor(UserFollowService)

--- a/lib/feature/user_profile/application/user_id_list_state.g.dart
+++ b/lib/feature/user_profile/application/user_id_list_state.g.dart
@@ -7,7 +7,7 @@ part of 'user_id_list_state.dart';
 // **************************************************************************
 
 String _$userIdListStateNotifierHash() =>
-    r'383957c22166e8a47b647c19d2da22e5b610707f';
+    r'cecb1e110501c686ba9127454d376310e248f37e';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/feature/user_profile/application/user_profile_for_write_notifier.g.dart
+++ b/lib/feature/user_profile/application/user_profile_for_write_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'user_profile_for_write_notifier.dart';
 // **************************************************************************
 
 String _$userProfileForWriteNotifierHash() =>
-    r'7ce54fcefc9fc37f023c9e2f499f27a2891c9dfc';
+    r'd1fc0f6df5401ae05029510aab4da626e86e6d6b';
 
 /// UserProfileの更新に関する処理を行う
 ///

--- a/lib/feature/word/application/word_list_state_by_initial.g.dart
+++ b/lib/feature/word/application/word_list_state_by_initial.g.dart
@@ -7,7 +7,7 @@ part of 'word_list_state_by_initial.dart';
 // **************************************************************************
 
 String _$wordListStateByInitialNotifierHash() =>
-    r'95059dde307c5d832fd3802e0cd1ff3ccd757202';
+    r'b4c606264a8f20df15b0435886e1f5b9c04d3164';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/feature/word/application/word_list_state_by_search_word.g.dart
+++ b/lib/feature/word/application/word_list_state_by_search_word.g.dart
@@ -7,7 +7,7 @@ part of 'word_list_state_by_search_word.dart';
 // **************************************************************************
 
 String _$wordListStateBySearchWordNotifierHash() =>
-    r'7b5097dd44bf9d619b4b9b9b88692753c567bbec';
+    r'8d611347b384b716cc9d19e41d05496915684aaa';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'feature/auth/application/auth_service.dart';
 import 'feature/auth/application/auth_state.dart';
 import 'feature/force_event/application/app_config_state.dart';
 import 'feature/force_event/presentation/overlay_force_update_dialog.dart';
+import 'feature/force_event/presentation/overlay_in_maintenance_dialog.dart';
 import 'firebase_options/firebase_options.dart';
 import 'util/constant/theme_data.dart';
 import 'util/logger.dart';
@@ -88,6 +89,21 @@ class _MyAppState extends ConsumerState<MyApp> {
       theme: getThemeData(ThemeMode.light, context),
       darkTheme: getThemeData(ThemeMode.dark, context),
       builder: (context, child) {
+        final appMaintenance = ref.watch(appMaintenanceProvider);
+        if (appMaintenance == null) {
+          // ロード中の場合
+          return const Scaffold(body: OverlayLoadingWidget());
+        }
+        if (appMaintenance.inMaintenance) {
+          // メンテナンス中の場合
+          return Stack(
+            children: [
+              child!,
+              OverlayInMaintenanceDialog(appMaintenance: appMaintenance),
+            ],
+          );
+        }
+
         // TODO(me): asyncValue.whenがネストしているのなんとかしたい
         // 強制アップデート関連の処理
         final asyncIsRequiredUpdate = ref.watch(isRequiredAppUpdateProvider);

--- a/lib/util/constant/firestore_collections.dart
+++ b/lib/util/constant/firestore_collections.dart
@@ -78,4 +78,9 @@ class AppConfigCollection {
   // Field
   static const minAppVersionForIos = 'minAppVersionForIos';
   static const minAppVersionForAndroid = 'minAppVersionForAndroid';
+  static const maintenanceMap = 'maintenanceMap';
+
+  // [maintenanceMap] のKey
+  static const inMaintenance = 'inMaintenance';
+  static const scheduledEndTime = 'scheduledEndTime';
 }

--- a/lib/util/constant/url.dart
+++ b/lib/util/constant/url.dart
@@ -1,0 +1,2 @@
+const latestInformationPage =
+    'https://almondine-ixora-d9e.notion.site/8e8ca7ad482a473099743dddb3b930ab?pvs=4';

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,13 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_linux/file_selector_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -16,6 +16,7 @@ import firebase_storage
 import package_info_plus
 import path_provider_foundation
 import sqflite
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
@@ -29,4 +30,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1202,6 +1202,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: b1c9e98774adf8820c96fbc7ae3601231d324a7d5ebd8babe27b6dfac91357ba
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "31222ffb0063171b526d3e569079cf1f8b294075ba323443fdc690842bfd4def"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.0"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "4ac97281cf60e2e8c5cc703b2b28528f9b50c8f7cebc71df6bdf0845f647268a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.0"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "9f2d390e096fdbe1e6e6256f97851e51afc2d9c423d3432f1d6a02a8a9a8b9fd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: b7244901ea3cf489c5335bdacda07264a6e960b1c1b1a9f91e4bc371d9e68234
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "980e8d9af422f477be6948bdfb68df8433be71f5743a188968b0c1b887807e50"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "7fd2f55fe86cea2897b963e864dc01a7eb0719ecc65fcef4c1cc3d686d718bb2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "7754a1ad30ee896b265f8d14078b0513a4dba28d358eabb9d5f339886f4a1adc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   riverpod_annotation: ^2.2.0
   roggle: ^0.4.2+1
   shimmer: ^3.0.0
+  url_launcher: ^6.2.1
   version: ^3.0.2
 
   # Firebase関連

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <file_selector_windows/file_selector_windows.h>
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FileSelectorWindowsRegisterWithRegistrar(
@@ -17,4 +18,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
   firebase_auth
   firebase_core
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
# 対象Issue

- #44 

# やった事

- メンテナンス時に表示するUIを実装
- Webページへの遷移を実装

# やらなかった事

# 動作確認

- iPhone11 (実機) で実施

# その他



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - アプリにURLを開く機能を追加しました。
  - メンテナンス情報を取得し、アプリがメンテナンス中でない場合に情報を表示する新しい機能を追加しました。
  - メンテナンスモードや予定されたメンテナンス終了時間を管理する新しい`AppMaintenance`クラスを導入しました。
  - メンテナンス中に表示されるオーバーレイダイアログを新たに追加しました。

- **バグ修正**
  - ハッシュ値の更新を含む複数のファイルでの変更を行いました。

- **ドキュメント**
  - メンテナンス関連の新しい定数を追加しました。

- **リファクタ**
  - メンテナンスモードの状態管理ロジックを統合しました。

- **スタイル**
  - なし

- **テスト**
  - なし

- **チョア**
  - Linux、macOS、Windows向けにURLランチャープラグインを追加しました。

- **リバート**
  - なし

<!-- end of auto-generated comment: release notes by coderabbit.ai -->