### PR TITLE
お問い合わせ / ユーザー報告を実装

### DIFF
--- a/lib/core/common_widget/button/other_user_action_icon_button.dart
+++ b/lib/core/common_widget/button/other_user_action_icon_button.dart
@@ -58,11 +58,16 @@ class OtherUserActionIconButton extends ConsumerWidget {
     return asyncMutedUserIdList.maybeWhen(
       orElse: () => const SizedBox.shrink(),
       data: (mutedUserIdList) {
-        // TODO(me): 雑に!で取得しているが、問題ないか確認する
-        final ownerProfile = ref.read(userProfileProvider(ownerId)).value!;
+        final ownerProfile = ref.read(userProfileProvider(ownerId)).value;
+
         final currentUserId = ref.read(userIdProvider)!;
         final currentUserProfile =
-            ref.read(userProfileProvider(currentUserId)).value!;
+            ref.read(userProfileProvider(currentUserId)).value;
+
+        // ownerもしくはcurrentUserがnullの場合はなにも表示しない
+        if (ownerProfile == null || currentUserProfile == null) {
+          return const SizedBox.shrink();
+        }
 
         final items = createMenuItems(
           mutedUserIdList,

--- a/lib/core/common_widget/button/other_user_action_icon_button.dart
+++ b/lib/core/common_widget/button/other_user_action_icon_button.dart
@@ -130,8 +130,8 @@ enum PullDownMenuItemForUserAction {
         return PullDownMenuItem(
           onTap: () {
             final url = userReportFormUrl(
-              targetUserProfile.publicId,
-              currentUserProfile.publicId,
+              currentUserPublicId: currentUserProfile.publicId,
+              targetUserPublicId: targetUserProfile.publicId,
             );
             ref.read(launchURLProvider(url));
           },

--- a/lib/core/common_widget/error_and_retry_widget.dart
+++ b/lib/core/common_widget/error_and_retry_widget.dart
@@ -1,18 +1,26 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../feature/auth/application/auth_state.dart';
+import '../../feature/user_profile/application/user_profile_state.dart';
+import '../../util/constant/url.dart';
+import '../common_provider/launch_url.dart';
 import 'button/primary_filled_button.dart';
+import 'button/secondary_outlined_button.dart';
 
-class ErrorAndRetryWidget extends StatelessWidget {
+class ErrorAndRetryWidget extends ConsumerWidget {
   const ErrorAndRetryWidget({
     super.key,
     required this.onRetry,
+    this.showInquireButton = false,
   });
 
   final VoidCallback onRetry;
+  final bool showInquireButton;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Column(
       children: [
         Icon(
@@ -36,6 +44,26 @@ class ErrorAndRetryWidget extends StatelessWidget {
         ),
         const SizedBox(height: 24),
         PrimaryFilledButton(onPressed: onRetry, text: '再読み込み'),
+        showInquireButton
+            ? Column(
+                children: [
+                  const SizedBox(height: 24),
+                  SecondaryOutlinedButton(
+                    onPressed: () {
+                      final currentUserId = ref.read(userIdProvider)!;
+                      final currentUserProfile =
+                          ref.read(userProfileProvider(currentUserId)).value;
+                      final url = inquireFormUrl(
+                        currentUserPublicId: currentUserProfile?.publicId,
+                      );
+
+                      ref.read(launchURLProvider(url));
+                    },
+                    text: '運営へお問い合わせ',
+                  ),
+                ],
+              )
+            : const SizedBox.shrink(),
       ],
     );
   }

--- a/lib/core/common_widget/error_and_retry_widget.dart
+++ b/lib/core/common_widget/error_and_retry_widget.dart
@@ -53,9 +53,8 @@ class ErrorAndRetryWidget extends ConsumerWidget {
                       final currentUserId = ref.read(userIdProvider)!;
                       final currentUserProfile =
                           ref.read(userProfileProvider(currentUserId)).value;
-                      final url = inquireFormUrl(
-                        currentUserPublicId: currentUserProfile?.publicId,
-                      );
+                      final url =
+                          inquireFormUrl(currentUserProfile?.publicId ?? '');
 
                       ref.read(launchURLProvider(url));
                     },

--- a/lib/feature/setting/presentation/setting_page.dart
+++ b/lib/feature/setting/presentation/setting_page.dart
@@ -3,9 +3,13 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/common_provider/launch_url.dart';
 import '../../../core/common_widget/shimmer_widget.dart';
 import '../../../core/router/app_router.dart';
+import '../../../util/constant/url.dart';
+import '../../auth/application/auth_state.dart';
 import '../../user_config/application/user_config_state.dart';
+import '../../user_profile/application/user_profile_state.dart';
 
 @RoutePage()
 class SettingRouterPage extends AutoRouter {
@@ -70,7 +74,14 @@ class SettingPage extends ConsumerWidget {
             SettingTileButton(
               trailingIcon: const Icon(CupertinoIcons.mail),
               label: 'お問い合わせ',
-              onTap: () {}, // TODO(me): お問い合わせフォームへ遷移（WebToでGoogleフォーム）
+              onTap: () {
+                final currentUserId = ref.read(userIdProvider)!;
+                final currentUserProfile =
+                    ref.read(userProfileProvider(currentUserId)).value!;
+                final url = inquireFormUrl(currentUserProfile.publicId);
+                
+                ref.read(launchURLProvider(url));
+              },
             ),
             const SizedBox(height: 24),
             SettingTileButton(

--- a/lib/feature/setting/presentation/setting_page.dart
+++ b/lib/feature/setting/presentation/setting_page.dart
@@ -78,9 +78,7 @@ class SettingPage extends ConsumerWidget {
                 final currentUserId = ref.read(userIdProvider)!;
                 final currentUserProfile =
                     ref.read(userProfileProvider(currentUserId)).value;
-                final url = inquireFormUrl(
-                  currentUserPublicId: currentUserProfile?.publicId,
-                );
+                final url = inquireFormUrl(currentUserProfile?.publicId ?? '');
 
                 ref.read(launchURLProvider(url));
               },

--- a/lib/feature/setting/presentation/setting_page.dart
+++ b/lib/feature/setting/presentation/setting_page.dart
@@ -77,9 +77,11 @@ class SettingPage extends ConsumerWidget {
               onTap: () {
                 final currentUserId = ref.read(userIdProvider)!;
                 final currentUserProfile =
-                    ref.read(userProfileProvider(currentUserId)).value!;
-                final url = inquireFormUrl(currentUserProfile.publicId);
-                
+                    ref.read(userProfileProvider(currentUserId)).value;
+                final url = inquireFormUrl(
+                  currentUserPublicId: currentUserProfile?.publicId,
+                );
+
                 ref.read(launchURLProvider(url));
               },
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -125,6 +125,7 @@ class _MyAppState extends ConsumerState<MyApp> {
                     child: ErrorAndRetryWidget(
                       onRetry: () =>
                           ref.invalidate(isRequiredAppUpdateProvider),
+                      showInquireButton: true,
                     ),
                   ),
                 ],

--- a/lib/util/constant/url.dart
+++ b/lib/util/constant/url.dart
@@ -4,3 +4,7 @@ const latestInformationPage =
 String userReportFormUrl(String targetUserId, String currentUserId) {
   return 'https://docs.google.com/forms/d/e/1FAIpQLSe_Y83WDspTgZIN0obOtFxpCM3IPskdPHkQ30Rtw-mrvRmSeg/viewform?usp=pp_url&entry.1412333435=$targetUserId&entry.399122039=$currentUserId';
 }
+
+String inquireFormUrl(String currentUserId) {
+  return 'https://docs.google.com/forms/d/e/1FAIpQLScVQ21a8-CtMRwD7Syy3AZfK07SpZQQCjYSuqNNvoA4g7rSsw/viewform?usp=pp_url&entry.2104212620=$currentUserId';
+}

--- a/lib/util/constant/url.dart
+++ b/lib/util/constant/url.dart
@@ -1,2 +1,6 @@
 const latestInformationPage =
     'https://almondine-ixora-d9e.notion.site/8e8ca7ad482a473099743dddb3b930ab?pvs=4';
+
+String userReportFormUrl(String targetUserId, String currentUserId) {
+  return 'https://docs.google.com/forms/d/e/1FAIpQLSe_Y83WDspTgZIN0obOtFxpCM3IPskdPHkQ30Rtw-mrvRmSeg/viewform?usp=pp_url&entry.1412333435=$targetUserId&entry.399122039=$currentUserId';
+}

--- a/lib/util/constant/url.dart
+++ b/lib/util/constant/url.dart
@@ -1,10 +1,13 @@
 const latestInformationPage =
     'https://almondine-ixora-d9e.notion.site/8e8ca7ad482a473099743dddb3b930ab?pvs=4';
 
-String userReportFormUrl(String targetUserId, String currentUserId) {
-  return 'https://docs.google.com/forms/d/e/1FAIpQLSe_Y83WDspTgZIN0obOtFxpCM3IPskdPHkQ30Rtw-mrvRmSeg/viewform?usp=pp_url&entry.1412333435=$targetUserId&entry.399122039=$currentUserId';
+String userReportFormUrl({
+  String? targetUserPublicId = '',
+  String? currentUserPublicId = '',
+}) {
+  return 'https://docs.google.com/forms/d/e/1FAIpQLSe_Y83WDspTgZIN0obOtFxpCM3IPskdPHkQ30Rtw-mrvRmSeg/viewform?usp=pp_url&entry.1412333435=$targetUserPublicId&entry.399122039=$currentUserPublicId';
 }
 
-String inquireFormUrl(String currentUserId) {
-  return 'https://docs.google.com/forms/d/e/1FAIpQLScVQ21a8-CtMRwD7Syy3AZfK07SpZQQCjYSuqNNvoA4g7rSsw/viewform?usp=pp_url&entry.2104212620=$currentUserId';
+String inquireFormUrl({String? currentUserPublicId = ''}) {
+  return 'https://docs.google.com/forms/d/e/1FAIpQLScVQ21a8-CtMRwD7Syy3AZfK07SpZQQCjYSuqNNvoA4g7rSsw/viewform?usp=pp_url&entry.2104212620=$currentUserPublicId';
 }

--- a/lib/util/constant/url.dart
+++ b/lib/util/constant/url.dart
@@ -2,12 +2,12 @@ const latestInformationPage =
     'https://almondine-ixora-d9e.notion.site/8e8ca7ad482a473099743dddb3b930ab?pvs=4';
 
 String userReportFormUrl({
-  String? targetUserPublicId = '',
-  String? currentUserPublicId = '',
+  required String targetUserPublicId,
+  required String currentUserPublicId,
 }) {
   return 'https://docs.google.com/forms/d/e/1FAIpQLSe_Y83WDspTgZIN0obOtFxpCM3IPskdPHkQ30Rtw-mrvRmSeg/viewform?usp=pp_url&entry.1412333435=$targetUserPublicId&entry.399122039=$currentUserPublicId';
 }
 
-String inquireFormUrl({String? currentUserPublicId = ''}) {
+String inquireFormUrl(String currentUserPublicId) {
   return 'https://docs.google.com/forms/d/e/1FAIpQLScVQ21a8-CtMRwD7Syy3AZfK07SpZQQCjYSuqNNvoA4g7rSsw/viewform?usp=pp_url&entry.2104212620=$currentUserPublicId';
 }

--- a/lib/util/constant/url.dart
+++ b/lib/util/constant/url.dart
@@ -5,9 +5,9 @@ String userReportFormUrl({
   required String targetUserPublicId,
   required String currentUserPublicId,
 }) {
-  return 'https://docs.google.com/forms/d/e/1FAIpQLSe_Y83WDspTgZIN0obOtFxpCM3IPskdPHkQ30Rtw-mrvRmSeg/viewform?usp=pp_url&entry.1412333435=$targetUserPublicId&entry.399122039=$currentUserPublicId';
+  return 'https://docs.google.com/forms/d/e/1FAIpQLSe_Y83WDspTgZIN0obOtFxpCM3IPskdPHkQ30Rtw-mrvRmSeg/viewform?usp=pp_url&entry.1412333435=${Uri.encodeComponent(targetUserPublicId)}&entry.399122039=${Uri.encodeComponent(currentUserPublicId)}';
 }
 
 String inquireFormUrl(String currentUserPublicId) {
-  return 'https://docs.google.com/forms/d/e/1FAIpQLScVQ21a8-CtMRwD7Syy3AZfK07SpZQQCjYSuqNNvoA4g7rSsw/viewform?usp=pp_url&entry.2104212620=$currentUserPublicId';
+  return 'https://docs.google.com/forms/d/e/1FAIpQLScVQ21a8-CtMRwD7Syy3AZfK07SpZQQCjYSuqNNvoA4g7rSsw/viewform?usp=pp_url&entry.2104212620=${Uri.encodeComponent(currentUserPublicId)}';
 }


### PR DESCRIPTION
# 対象Issue

- #33 

# やった事

- お問い合わせ / ユーザー報告の実装

# やらなかった事

# 動作確認

- iPhone11 (実機) で実施

# その他



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ユーザーのアクションに関するメニューアイテムの作成機能に、プロファイル情報を含む新しいパラメータを追加しました。
  - エラーと再試行ウィジェットに問い合わせボタンの表示オプションを追加しました。
  - 設定ページにおいて、特定の設定項目をタップした際に問い合わせフォームを開く機能を追加しました。

- **バグ修正**
  - ユーザーをミュート、アンミュートする機能において、対象ユーザーのプロファイルIDを正しく使用するように修正しました。

- **ドキュメント**
  - 新しいURL関数 `userReportFormUrl` と `inquireFormUrl` を追加し、特定のクエリパラメータを含むGoogleフォームのURLを生成する機能をドキュメントに記載しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->