### PR TITLE
定義投稿の動線を追加

### DIFF
--- a/lib/core/common_provider/launch_url.g.dart
+++ b/lib/core/common_provider/launch_url.g.dart
@@ -6,7 +6,7 @@ part of 'launch_url.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$launchURLHash() => r'5bb5ab81d6ef3c799c2e18651b9f99d2bd2dae1f';
+String _$launchURLHash() => r'55fc93b1e3e47d3746b98d00c8f434b5963cb4c9';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/core/common_widget/button/post_definition_fab.dart
+++ b/lib/core/common_widget/button/post_definition_fab.dart
@@ -2,18 +2,12 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
-import '../../../feature/definition/domain/definition.dart';
 import '../../../feature/definition/util/write_definition_form_type.dart';
 import '../../router/app_router.dart';
 
 /// 定義投稿画面へ遷移するFAB
-///
-/// 定義投稿画面にて、TextFieldなどに初期表示させたい項目がある場合[definition]として渡す。
-/// ない場合はnullを渡す。
 class PostDefinitionFAB extends StatelessWidget {
-  const PostDefinitionFAB({super.key, required this.definition});
-
-  final Definition? definition;
+  const PostDefinitionFAB({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +17,7 @@ class PostDefinitionFAB extends StatelessWidget {
       onPressed: () {
         context.pushRoute(
           PostDefinitionRoute(
-            initialDefinition: definition,
+            initialDefinitionForWrite: null,
             autoFocusForm: WriteDefinitionFormType.word,
           ),
         );

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -4,6 +4,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../base_page.dart';
 import '../../feature/definition/domain/definition.dart';
+import '../../feature/definition/domain/definition_for_write.dart';
 import '../../feature/definition/presentation/page/definition_detail/definition_detail_page.dart';
 import '../../feature/definition/presentation/page/edit_definition/edit_definition_page.dart';
 import '../../feature/definition/presentation/page/home/home_page.dart';

--- a/lib/core/router/app_router.gr.dart
+++ b/lib/core/router/app_router.gr.dart
@@ -159,7 +159,7 @@ abstract class _$AppRouter extends RootStackRouter {
         routeData: routeData,
         child: PostDefinitionPage(
           key: args.key,
-          initialDefinition: args.initialDefinition,
+          initialDefinitionForWrite: args.initialDefinitionForWrite,
           autoFocusForm: args.autoFocusForm,
         ),
       );
@@ -690,14 +690,14 @@ class MyLicenseRoute extends PageRouteInfo<void> {
 class PostDefinitionRoute extends PageRouteInfo<PostDefinitionRouteArgs> {
   PostDefinitionRoute({
     Key? key,
-    required Definition? initialDefinition,
+    required DefinitionForWrite? initialDefinitionForWrite,
     required WriteDefinitionFormType? autoFocusForm,
     List<PageRouteInfo>? children,
   }) : super(
           PostDefinitionRoute.name,
           args: PostDefinitionRouteArgs(
             key: key,
-            initialDefinition: initialDefinition,
+            initialDefinitionForWrite: initialDefinitionForWrite,
             autoFocusForm: autoFocusForm,
           ),
           initialChildren: children,
@@ -712,19 +712,19 @@ class PostDefinitionRoute extends PageRouteInfo<PostDefinitionRouteArgs> {
 class PostDefinitionRouteArgs {
   const PostDefinitionRouteArgs({
     this.key,
-    required this.initialDefinition,
+    required this.initialDefinitionForWrite,
     required this.autoFocusForm,
   });
 
   final Key? key;
 
-  final Definition? initialDefinition;
+  final DefinitionForWrite? initialDefinitionForWrite;
 
   final WriteDefinitionFormType? autoFocusForm;
 
   @override
   String toString() {
-    return 'PostDefinitionRouteArgs{key: $key, initialDefinition: $initialDefinition, autoFocusForm: $autoFocusForm}';
+    return 'PostDefinitionRouteArgs{key: $key, initialDefinitionForWrite: $initialDefinitionForWrite, autoFocusForm: $autoFocusForm}';
   }
 }
 

--- a/lib/feature/definition/application/definition_for_write_notifier.dart
+++ b/lib/feature/definition/application/definition_for_write_notifier.dart
@@ -23,13 +23,7 @@ class DefinitionForWriteNotifier extends _$DefinitionForWriteNotifier {
     DefinitionForWrite? definitionForWrite,
   ) async {
     if (definitionForWrite == null) {
-      _initialState = const DefinitionForWrite(
-        id: null,
-        word: '',
-        wordReading: '',
-        isPublic: true,
-        definition: '',
-      );
+      _initialState = DefinitionForWrite.empty();
     } else {
       _initialState = definitionForWrite;
     }

--- a/lib/feature/definition/application/definition_for_write_notifier.g.dart
+++ b/lib/feature/definition/application/definition_for_write_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'definition_for_write_notifier.dart';
 // **************************************************************************
 
 String _$definitionForWriteNotifierHash() =>
-    r'78a03db2f2422ce73a9382763ee8652845363f59';
+    r'a747afe6fa869883b57d8b1399c12844e2a3191f';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/feature/definition/domain/definition_for_write.dart
+++ b/lib/feature/definition/domain/definition_for_write.dart
@@ -3,6 +3,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import '../../../util/constant/firestore_collections.dart';
 import '../../../util/constant/initial_main_group.dart';
 import '../../../util/constant/string_regex.dart';
+import '../../word/domain/word.dart';
 
 part 'definition_for_write.freezed.dart';
 
@@ -17,6 +18,28 @@ class DefinitionForWrite with _$DefinitionForWrite {
     required bool isPublic,
     required String definition,
   }) = _DefinitionForWrite;
+
+  factory DefinitionForWrite.empty() {
+    return const DefinitionForWrite(
+      id: null,
+      word: '',
+      wordReading: '',
+      isPublic: true,
+      definition: '',
+    );
+  }
+
+  /// [Word]から[DefinitionForWrite]を生成する
+  factory DefinitionForWrite.fromWord(Word word) {
+    return  DefinitionForWrite(
+      id: null,
+      word: word.word,
+      wordReading: word.reading,
+      isPublic: true,
+      definition: '',
+    );
+  }
+
   const DefinitionForWrite._();
 
   int get maxWordLength => 30;
@@ -80,7 +103,8 @@ class DefinitionForWrite with _$DefinitionForWrite {
     final isValidWord = outputWordError() == null && word.isNotEmpty;
     final isValidWordReading =
         outputWordReadingError() == null && wordReading.isNotEmpty;
-    final isValidDefinition = definition.isNotEmpty && definition.length <= maxDefinitionLength;
+    final isValidDefinition =
+        definition.isNotEmpty && definition.length <= maxDefinitionLength;
 
     return isValidWord && isValidWordReading && isValidDefinition;
   }

--- a/lib/feature/definition/presentation/component/self_definition_action_icon_button.dart
+++ b/lib/feature/definition/presentation/component/self_definition_action_icon_button.dart
@@ -114,7 +114,7 @@ class SelfDefinitionActionIconButton extends ConsumerWidget {
                   ..popRoute()
                   ..pushRoute(
                     PostDefinitionRoute(
-                      initialDefinition: definition,
+                      initialDefinitionForWrite: definition.toDefinitionForWrite(),
                       autoFocusForm: null,
                     ),
                   );

--- a/lib/feature/definition/presentation/page/definition_detail/definition_detail_page.dart
+++ b/lib/feature/definition/presentation/page/definition_detail/definition_detail_page.dart
@@ -201,7 +201,7 @@ class DefinitionDetailPage extends ConsumerWidget {
               ),
             ),
           ),
-          floatingActionButton: const PostDefinitionFAB(definition: null),
+          floatingActionButton: const PostDefinitionFAB(),
         );
       },
       loading: () {

--- a/lib/feature/definition/presentation/page/home/home_page.dart
+++ b/lib/feature/definition/presentation/page/home/home_page.dart
@@ -56,7 +56,7 @@ class HomePage extends StatelessWidget {
               ],
             ),
           ),
-          floatingActionButton: const PostDefinitionFAB(definition: null),
+          floatingActionButton: const PostDefinitionFAB(),
         ),
       ),
     );

--- a/lib/feature/definition/presentation/page/post_definition/post_definition_page.dart
+++ b/lib/feature/definition/presentation/page/post_definition/post_definition_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../application/definition_for_write_notifier.dart';
-import '../../../domain/definition.dart';
+import '../../../domain/definition_for_write.dart';
 import '../../../util/write_definition_form_type.dart';
 import '../../component/write_definition_base_page.dart';
 
@@ -12,21 +12,19 @@ import '../../component/write_definition_base_page.dart';
 class PostDefinitionPage extends ConsumerWidget {
   const PostDefinitionPage({
     super.key,
-    required this.initialDefinition,
+    required this.initialDefinitionForWrite,
     required this.autoFocusForm,
   });
 
   /// 遷移時にフォーカスするTextFormField。
   final WriteDefinitionFormType? autoFocusForm;
 
-  /// 初期値として持つ [Definition]。
+  /// 初期値として持つ [DefinitionForWrite]。
   /// TextFieldなどに初期表示させたい値がある場合はこの値を渡す。
-  final Definition? initialDefinition;
+  final DefinitionForWrite? initialDefinitionForWrite;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final initialDefinitionForWrite = initialDefinition?.toDefinitionForWrite();
-
     final asyncDefinitionForWrite = ref
         .watch(definitionForWriteNotifierProvider(initialDefinitionForWrite));
     final notifier = ref.watch(

--- a/lib/feature/user_profile/presentation/page/profile/profile_page.dart
+++ b/lib/feature/user_profile/presentation/page/profile/profile_page.dart
@@ -92,7 +92,7 @@ class ProfilePage extends ConsumerWidget {
               ],
             ),
           ),
-          floatingActionButton: const PostDefinitionFAB(definition: null),
+          floatingActionButton: const PostDefinitionFAB(),
         ),
       ),
     );

--- a/lib/feature/word/presentation/page/individual_dictionary_definition_list/individual_dictionary_definition_list.dart
+++ b/lib/feature/word/presentation/page/individual_dictionary_definition_list/individual_dictionary_definition_list.dart
@@ -47,7 +47,7 @@ class IndividualDictionaryDefinitionListPage extends ConsumerWidget {
           ],
         ),
       ),
-      floatingActionButton: const PostDefinitionFAB(definition: null),
+      floatingActionButton: const PostDefinitionFAB(),
     );
   }
 }

--- a/lib/feature/word/presentation/page/individual_dictionary_definition_list/individual_dictionary_definition_list.dart
+++ b/lib/feature/word/presentation/page/individual_dictionary_definition_list/individual_dictionary_definition_list.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../../core/common_widget/button/post_definition_fab.dart';
 import '../../../../../util/constant/initial_main_group.dart';
 import '../../../../definition/presentation/component/definition_list.dart';
 import '../../../../definition/util/definition_feed_type.dart';
@@ -46,6 +47,7 @@ class IndividualDictionaryDefinitionListPage extends ConsumerWidget {
           ],
         ),
       ),
+      floatingActionButton: const PostDefinitionFAB(definition: null),
     );
   }
 }

--- a/lib/feature/word/presentation/page/search_word_result/search_word_result_page.dart
+++ b/lib/feature/word/presentation/page/search_word_result/search_word_result_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../../../core/common_widget/button/back_icon_button.dart';
+import '../../../../../core/common_widget/button/post_definition_fab.dart';
 import '../../../../../core/common_widget/infinity_scroll_widget.dart';
 import '../../../application/word_list_state_by_search_word.dart';
 import '../../../domain/word.dart';
@@ -50,6 +51,7 @@ class SearchWordResultPage extends ConsumerWidget {
           ),
         ],
       ),
+      floatingActionButton: const PostDefinitionFAB(definition: null),
     );
   }
 }

--- a/lib/feature/word/presentation/page/search_word_result/search_word_result_page.dart
+++ b/lib/feature/word/presentation/page/search_word_result/search_word_result_page.dart
@@ -51,7 +51,7 @@ class SearchWordResultPage extends ConsumerWidget {
           ),
         ],
       ),
-      floatingActionButton: const PostDefinitionFAB(definition: null),
+      floatingActionButton: const PostDefinitionFAB(),
     );
   }
 }

--- a/lib/feature/word/presentation/page/word_list/word_list_page.dart
+++ b/lib/feature/word/presentation/page/word_list/word_list_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../../core/common_widget/button/back_icon_button.dart';
+import '../../../../../core/common_widget/button/post_definition_fab.dart';
 import '../../../../../core/common_widget/infinity_scroll_widget.dart';
 import '../../../../../util/constant/initial_main_group.dart';
 import '../../../application/word_list_state_by_initial.dart';
@@ -37,6 +38,7 @@ class WordListPage extends ConsumerWidget {
         shimmerTile: const WordTileShimmer(),
         shimmerTileNumber: 10,
       ),
+      floatingActionButton: const PostDefinitionFAB(definition: null),
     );
   }
 }

--- a/lib/feature/word/presentation/page/word_list/word_list_page.dart
+++ b/lib/feature/word/presentation/page/word_list/word_list_page.dart
@@ -38,7 +38,7 @@ class WordListPage extends ConsumerWidget {
         shimmerTile: const WordTileShimmer(),
         shimmerTileNumber: 10,
       ),
-      floatingActionButton: const PostDefinitionFAB(definition: null),
+      floatingActionButton: const PostDefinitionFAB(),
     );
   }
 }

--- a/lib/feature/word/presentation/page/word_top/word_top_page.dart
+++ b/lib/feature/word/presentation/page/word_top/word_top_page.dart
@@ -84,7 +84,7 @@ class WordTopPage extends ConsumerWidget {
               ],
             ),
           ),
-          floatingActionButton: const PostDefinitionFAB(definition: null),
+          floatingActionButton: const PostDefinitionFAB(),
         ),
       ),
     );

--- a/lib/feature/word/presentation/page/word_top/word_widget.dart
+++ b/lib/feature/word/presentation/page/word_top/word_widget.dart
@@ -1,9 +1,14 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../../core/common_widget/button/primary_filled_button.dart';
 import '../../../../../core/common_widget/error_and_retry_widget.dart';
+import '../../../../../core/router/app_router.dart';
 import '../../../../../util/logger.dart';
+import '../../../../definition/domain/definition_for_write.dart';
+import '../../../../definition/util/write_definition_form_type.dart';
 import '../../../application/word_state.dart';
 import 'word_widget_shimmer.dart';
 
@@ -42,6 +47,23 @@ class WordWidget extends ConsumerWidget {
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
                     ),
               ),
+              const SizedBox(height: 8),
+              Center(
+                child: PrimaryFilledButton(
+                  onPressed: () {
+                    final definitionForWrite =
+                        DefinitionForWrite.fromWord(word);
+                    context.pushRoute(
+                      PostDefinitionRoute(
+                        initialDefinitionForWrite: definitionForWrite,
+                        autoFocusForm: WriteDefinitionFormType.definition,
+                      ),
+                    );
+                  },
+                  text: 'この語句の定義を投稿する',
+                ),
+              ),
+              const SizedBox(height: 8),
             ],
           ),
         );


### PR DESCRIPTION
# 対象Issue

- #82 

# やった事

- 投稿用のFABを一部画面に追加
- 語句Top画面から、語句を引き継いで投稿できるよう実装

# やらなかった事

# 動作確認

- iPhone11 (実機) で実施

# その他



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 検索機能がアプリに追加されました。
  - 投稿定義ボタンの挙動が更新され、新しいパラメータが追加されました。
  - 新しいファクトリコンストラクタが定義クラスに追加され、デフォルト値でインスタンスを作成できるようになりました。

- **バグ修正**
  - 定義の有効性を判断するロジックが読みやすくなるように改善されました。

- **ドキュメント**
  - `definition_for_write.dart`のインポート文が追加されました。

- **リファクタリング**
  - `PostDefinitionRoute`のパラメータが更新され、関連するクラスに変更が加えられました。
  - `DefinitionForWriteNotifier`の初期化ロジックが簡素化されました。

- **スタイル**
  - 検索バーのスタイルが追加されました。

- **テスト**
  - テスト用のハッシュ値が更新されました。

- **その他の変更**
  - 複数のページに投稿定義ボタンが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->