### PR TITLE
公開設定の変更を実装

### DIFF
--- a/lib/feature/definition/presentation/component/select_post_type_button.dart
+++ b/lib/feature/definition/presentation/component/select_post_type_button.dart
@@ -48,7 +48,7 @@ class SelectPostTypeButton extends ConsumerWidget {
                     isPublic: true,
                   );
                 },
-                title: DefinitionPostType.public.label,
+                title: DefinitionPostType.public.labelForWrite,
                 icon: DefinitionPostType.public.icon,
               ),
               PullDownMenuItem(
@@ -57,7 +57,7 @@ class SelectPostTypeButton extends ConsumerWidget {
                     isPublic: false,
                   );
                 },
-                title: DefinitionPostType.private.label,
+                title: DefinitionPostType.private.labelForWrite,
                 icon: DefinitionPostType.private.icon,
               ),
             ],
@@ -70,11 +70,11 @@ class SelectPostTypeButton extends ConsumerWidget {
             Icon(
               postType.icon,
               color: Theme.of(context).colorScheme.onSurface,
-              size: postType.lergeIconSize,
+              size: postType.largeIconSize,
             ),
             const SizedBox(width: 8),
             Text(
-              postType.label,
+              postType.labelForWrite,
               style: Theme.of(context).textTheme.titleLarge,
             ),
             const SizedBox(width: 8),

--- a/lib/feature/definition/presentation/component/self_definition_action_icon_button.dart
+++ b/lib/feature/definition/presentation/component/self_definition_action_icon_button.dart
@@ -6,7 +6,9 @@ import 'package:pull_down_button/pull_down_button.dart';
 
 import '../../../../core/router/app_router.dart';
 import '../../../../util/extension/date_time_extension.dart';
+import '../../application/definition_service.dart';
 import '../../domain/definition.dart';
+import '../../util/definition_post_type.dart';
 
 class SelfDefinitionActionIconButton extends ConsumerWidget {
   const SelfDefinitionActionIconButton({super.key, required this.definition});
@@ -19,8 +21,23 @@ class SelfDefinitionActionIconButton extends ConsumerWidget {
 
     // プルダウンメニューの項目を作成する
     List<PullDownMenuEntry> createMenuItems(Definition definition) {
+      final targetPostType = definition.isPublic
+          ? DefinitionPostType.private
+          : DefinitionPostType.public;
+
       return [
-        PullDownMenuItemForDefinitionAction.editDefinition.item(
+        PullDownMenuItem(
+          title: targetPostType.labelForChange,
+          icon: targetPostType.icon,
+          onTap: () {
+            ref
+                .read(definitionServiceProvider.notifier)
+                .updatePostType(definition);
+          },
+        ),
+        PullDownMenuItem(
+          title: 'この定義を編集',
+          icon: CupertinoIcons.pencil,
           onTap: () {
             // 投稿から1時間以内の定義のみ編集可能
             final canEdit = !definition.createdAt.hasOneHourPassed();
@@ -34,7 +51,9 @@ class SelfDefinitionActionIconButton extends ConsumerWidget {
             );
           },
         ),
-        PullDownMenuItemForDefinitionAction.deleteDefinition.item(
+        PullDownMenuItem(
+          title: 'この定義を削除',
+          icon: CupertinoIcons.trash,
           onTap: () {},
         ),
       ];
@@ -114,7 +133,8 @@ class SelfDefinitionActionIconButton extends ConsumerWidget {
                   ..popRoute()
                   ..pushRoute(
                     PostDefinitionRoute(
-                      initialDefinitionForWrite: definition.toDefinitionForWrite(),
+                      initialDefinitionForWrite:
+                          definition.toDefinitionForWrite(),
                       autoFocusForm: null,
                     ),
                   );
@@ -133,27 +153,5 @@ class SelfDefinitionActionIconButton extends ConsumerWidget {
         );
       },
     );
-  }
-}
-
-enum PullDownMenuItemForDefinitionAction {
-  editDefinition,
-  deleteDefinition;
-
-  PullDownMenuItem item({required VoidCallback onTap}) {
-    switch (this) {
-      case PullDownMenuItemForDefinitionAction.editDefinition:
-        return PullDownMenuItem(
-          onTap: onTap,
-          title: 'この定義を編集',
-          icon: CupertinoIcons.pencil,
-        );
-      case PullDownMenuItemForDefinitionAction.deleteDefinition:
-        return PullDownMenuItem(
-          onTap: onTap,
-          title: 'この定義を削除',
-          icon: CupertinoIcons.trash,
-        );
-    }
   }
 }

--- a/lib/feature/definition/presentation/component/self_definition_action_icon_button.dart
+++ b/lib/feature/definition/presentation/component/self_definition_action_icon_button.dart
@@ -20,7 +20,7 @@ class SelfDefinitionActionIconButton extends ConsumerWidget {
     final globalKey = GlobalKey();
 
     // プルダウンメニューの項目を作成する
-    List<PullDownMenuEntry> createMenuItems(Definition definition) {
+    List<PullDownMenuEntry> createMenuItems() {
       final targetPostType = definition.isPublic
           ? DefinitionPostType.private
           : DefinitionPostType.public;
@@ -30,9 +30,7 @@ class SelfDefinitionActionIconButton extends ConsumerWidget {
           title: targetPostType.labelForChange,
           icon: targetPostType.icon,
           onTap: () {
-            ref
-                .read(definitionServiceProvider.notifier)
-                .updatePostType(definition);
+            _showChangePostTypeConfirmDialog(context, ref);
           },
         ),
         PullDownMenuItem(
@@ -74,7 +72,7 @@ class SelfDefinitionActionIconButton extends ConsumerWidget {
         await showPullDownMenu(
           context: context,
           position: position,
-          items: createMenuItems(definition),
+          items: createMenuItems(),
         );
       },
     );
@@ -145,6 +143,75 @@ class SelfDefinitionActionIconButton extends ConsumerWidget {
                   '作成する',
                   style: Theme.of(context).textTheme.titleMedium!.copyWith(
                         color: Theme.of(context).colorScheme.primary,
+                      ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  /// 公開設定を変更してもいいか確認するダイアログを表示する
+  Future<void> _showChangePostTypeConfirmDialog(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    final afterUpdatePostType = definition.isPublic
+        ? DefinitionPostType.private
+        : DefinitionPostType.public;
+
+    await showDialog<dynamic>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          elevation: 0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          contentPadding: const EdgeInsets.only(
+            top: 16,
+            bottom: 8,
+          ),
+          title: const Center(child: Text('確認')),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                afterUpdatePostType.confirmChangeMessage,
+                overflow: TextOverflow.clip,
+              ),
+            ],
+          ),
+          actionsAlignment: MainAxisAlignment.spaceEvenly,
+          actionsPadding: const EdgeInsets.only(bottom: 16),
+          actions: [
+            InkWell(
+              onTap: () {
+                context.popRoute();
+              },
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  'しない',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ),
+            ),
+            InkWell(
+              onTap: () {
+                ref
+                    .read(definitionServiceProvider.notifier)
+                    .updatePostType(definition);
+                context.popRoute();
+              },
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  'する',
+                  style: Theme.of(context).textTheme.titleMedium!.copyWith(
+                        color: Theme.of(context).colorScheme.error,
                       ),
                 ),
               ),

--- a/lib/feature/definition/repository/write_definition_repository.dart
+++ b/lib/feature/definition/repository/write_definition_repository.dart
@@ -121,6 +121,16 @@ class WriteDefinitionRepository {
     return docRef.id;
   }
 
+  Future<void> updatePostType({
+    required String definitionId,
+    required bool isPublic,
+  }) async {
+    await _definitionsCollectionRef.doc(definitionId).update({
+      DefinitionsCollection.isPublic: isPublic,
+      updatedAtFieldName: FieldValue.serverTimestamp(),
+    });
+  }
+
   Future<void> likeDefinition(String definitionId, String userId) async {
     // transactionを使い、複数の処理が全て成功した場合のみ、処理を完了させる
     await firestore.runTransaction((transaction) async {

--- a/lib/feature/definition/util/definition_post_type.dart
+++ b/lib/feature/definition/util/definition_post_type.dart
@@ -4,12 +4,30 @@ enum DefinitionPostType {
   public,
   private;
 
-  String get label {
+  String get labelForWrite {
     switch (this) {
       case DefinitionPostType.public:
         return '全体に公開';
       case DefinitionPostType.private:
         return '非公開';
+    }
+  }
+
+  String get labelForChange {
+    switch (this) {
+      case DefinitionPostType.public:
+        return '全体に公開する';
+      case DefinitionPostType.private:
+        return '非公開にする';
+    }
+  }
+
+  String get completeChangeMessage {
+    switch (this) {
+      case DefinitionPostType.public:
+        return '全体に公開しました';
+      case DefinitionPostType.private:
+        return '非公開にしました';
     }
   }
 
@@ -22,7 +40,7 @@ enum DefinitionPostType {
     }
   }
 
-  double get lergeIconSize {
+  double get largeIconSize {
     switch (this) {
       case DefinitionPostType.public:
         return 32;

--- a/lib/feature/definition/util/definition_post_type.dart
+++ b/lib/feature/definition/util/definition_post_type.dart
@@ -22,6 +22,15 @@ enum DefinitionPostType {
     }
   }
 
+  String get confirmChangeMessage {
+    switch (this) {
+      case DefinitionPostType.public:
+        return '全体に公開しますか？';
+      case DefinitionPostType.private:
+        return '非公開にしますか？';
+    }
+  }
+
   String get completeChangeMessage {
     switch (this) {
       case DefinitionPostType.public:


### PR DESCRIPTION
# 対象Issue

- #70 

# やった事

- 公開設定の変更
- 公開設定変更時の確認ダイアログ表示

# やらなかった事

# 動作確認

- iPhone11 (実機) で実施

# その他



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 投稿タイプの更新機能を追加し、UIの更新とトーストメッセージの表示を行う。
  - 投稿タイプ選択ボタンのラベルとサイズを更新し、ユーザーインターフェースの視覚表現を改善。

- **バグ修正**
  - `DefinitionPostType`の列挙体のラベル名を修正し、新しいゲッターを追加。

- **リファクタリング**
  - `DefinitionService`クラスに新しいメソッドを追加し、既存の機能に影響を与えずにコードを整理。
  - `SelectPostTypeButton`クラスと`SelfDefinitionActionIconButton`クラスのメソッドを更新し、より直接的な方法でメニューアイテムを作成。

- **ドキュメント**
  - `DefinitionPostType`の列挙体のドキュメントを更新し、新しいプロパティと変更されたプロパティ名を反映。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->