### PR TITLE
定義投稿 / 編集時に特定のProviderをinvalidateするよう修正

### DIFF
--- a/lib/feature/definition/application/definition_for_write_notifier.dart
+++ b/lib/feature/definition/application/definition_for_write_notifier.dart
@@ -8,6 +8,7 @@ import '../../auth/application/auth_state.dart';
 import '../../word/repository/word_repository.dart';
 import '../domain/definition_for_write.dart';
 import '../repository/write_definition_repository.dart';
+import 'definition_id_list_state.dart';
 import 'definition_state.dart';
 
 part 'definition_for_write_notifier.g.dart';
@@ -82,7 +83,7 @@ class DefinitionForWriteNotifier extends _$DefinitionForWriteNotifier {
       return;
     }
 
-    // TODO(me): 適宜providerをinvalidateする
+    ref.invalidate(definitionIdListStateNotifierProvider);
 
     isLoadingOverlayNotifier.finishLoading();
     await ref.read(appRouterProvider).pop();
@@ -118,8 +119,9 @@ class DefinitionForWriteNotifier extends _$DefinitionForWriteNotifier {
       return;
     }
 
-    // 遷移元の画面を更新するためにinvalidateする
-    ref.invalidate(definitionProvider(definitionForWrite.id!));
+    ref
+      ..invalidate(definitionProvider(definitionForWrite.id!))
+      ..invalidate(definitionIdListStateNotifierProvider);
 
     isLoadingOverlayNotifier.finishLoading();
     await ref.read(appRouterProvider).pop();

--- a/lib/feature/definition/domain/definition_for_write.dart
+++ b/lib/feature/definition/domain/definition_for_write.dart
@@ -31,7 +31,7 @@ class DefinitionForWrite with _$DefinitionForWrite {
 
   /// [Word]から[DefinitionForWrite]を生成する
   factory DefinitionForWrite.fromWord(Word word) {
-    return  DefinitionForWrite(
+    return DefinitionForWrite(
       id: null,
       word: word.word,
       wordReading: word.reading,
@@ -114,7 +114,7 @@ class DefinitionForWrite with _$DefinitionForWrite {
       DefinitionsCollection.word: word,
       DefinitionsCollection.wordReading: wordReading,
       DefinitionsCollection.wordReadingInitialSubGroupLabel:
-          _wordReadingInitialLabel,
+          wordReadingInitialLabel,
       DefinitionsCollection.definition: definition,
       DefinitionsCollection.likesCount: 0,
       DefinitionsCollection.isPublic: isPublic,
@@ -127,7 +127,7 @@ class DefinitionForWrite with _$DefinitionForWrite {
       DefinitionsCollection.word: word,
       DefinitionsCollection.wordReading: wordReading,
       DefinitionsCollection.wordReadingInitialSubGroupLabel:
-          _wordReadingInitialLabel,
+          wordReadingInitialLabel,
       DefinitionsCollection.definition: definition,
       DefinitionsCollection.isPublic: isPublic,
       DefinitionsCollection.isEdited: true,
@@ -137,6 +137,5 @@ class DefinitionForWrite with _$DefinitionForWrite {
   bool get isEmptyAllFields =>
       word.isEmpty && wordReading.isEmpty && definition.isEmpty;
 
-  String get _wordReadingInitialLabel =>
-      InitialSubGroup.labelFromString(wordReading);
+  String get wordReadingInitialLabel => InitialSubGroup.fromString(wordReading).label;
 }

--- a/lib/feature/definition/presentation/component/self_definition_action_icon_button.dart
+++ b/lib/feature/definition/presentation/component/self_definition_action_icon_button.dart
@@ -126,7 +126,7 @@ class SelfDefinitionActionIconButton extends ConsumerWidget {
             ),
             InkWell(
               onTap: () {
-                // TODO(me): 適切な画面へ遷移させる
+                // TODO(me): ここから投稿した場合、投稿完了時に投稿した定義の詳細画面へ遷移したい
                 context
                   ..popRoute()
                   ..pushRoute(

--- a/lib/feature/definition/repository/write_definition_repository.dart
+++ b/lib/feature/definition/repository/write_definition_repository.dart
@@ -112,7 +112,7 @@ class WriteDefinitionRepository {
         WordsCollection.word: word,
         WordsCollection.reading: wordReading,
         WordsCollection.initialSubGroupLabel:
-            InitialSubGroup.labelFromString(wordReading),
+            InitialSubGroup.fromString(wordReading).label,
         createdAtFieldName: FieldValue.serverTimestamp(),
         updatedAtFieldName: FieldValue.serverTimestamp(),
       },

--- a/lib/feature/word/presentation/page/individual_dictionary/individual_dictionary_page.dart
+++ b/lib/feature/word/presentation/page/individual_dictionary/individual_dictionary_page.dart
@@ -37,7 +37,6 @@ class IndividualDictionaryPage extends ConsumerWidget {
           appBar: AppBar(
             title: Text('${targetUserProfile.name}の辞書'),
             leading: isTopRoute ? const ToSettingButton() : const BackButton(),
-            leadingWidth: 48,
           ),
           body: ListView(
             children: [

--- a/lib/util/constant/initial_main_group.dart
+++ b/lib/util/constant/initial_main_group.dart
@@ -290,23 +290,23 @@ enum InitialSubGroup {
     }
   }
 
-  static String labelFromString(String input) {
+  static InitialSubGroup fromString(String input) {
     final trimmed = input.trim();
     if (trimmed.isEmpty) {
-      return InitialSubGroup.other.label;
+      return InitialSubGroup.other;
     }
 
     final initial = trimmed.substring(0, 1);
 
     // ひらがな
     if (hiraganaRegex.hasMatch(initial)) {
-      return kanaMapping[initial]!.label;
+      return kanaMapping[initial]!;
     }
 
     // カタカナ
     if (katakanaRegex.hasMatch(initial)) {
       final hiraganaInitial = initial.katakanaToHiragana();
-      return kanaMapping[hiraganaInitial]!.label;
+      return kanaMapping[hiraganaInitial]!;
     }
 
     // アルファベット
@@ -315,21 +315,21 @@ enum InitialSubGroup {
           .firstWhere(
             (element) => element.label == initial.toUpperCase(),
           )
-          .label;
+          ;
     }
 
     // 数字
     if (numberRegex.hasMatch(initial)) {
-      return InitialSubGroup.number.label;
+      return InitialSubGroup.number;
     }
 
     // 記号
     if (basicSymbolRegex.hasMatch(initial)) {
-      return InitialSubGroup.basicSymbol.label;
+      return InitialSubGroup.basicSymbol;
     }
 
     // その他
-    return InitialSubGroup.other.label;
+    return InitialSubGroup.other;
   }
 }
 

--- a/lib/util/dummy_data/definitions_dummy.dart
+++ b/lib/util/dummy_data/definitions_dummy.dart
@@ -120,7 +120,7 @@ Future<void> addDefinitionDummy0to29(String flavorName) async {
       'word': words[i],
       'wordReading': readings[i],
       'wordReadingInitialSubGroupLabel':
-          InitialSubGroup.labelFromString(readings[i]),
+          InitialSubGroup.fromString(readings[i]),
       'authorId': 'user${Random().nextInt(20) + 1}',
       'definition': definitions[i],
       'likesCount': Random().nextInt(100),

--- a/lib/util/dummy_data/words_dummy.dart
+++ b/lib/util/dummy_data/words_dummy.dart
@@ -177,7 +177,7 @@ Future<void> _addWordsDummyToFirestore(
       'id': wordId,
       'word': words[i],
       'reading': readings[i],
-      'initialSubGroupLabel': InitialSubGroup.labelFromString(readings[i]),
+      'initialSubGroupLabel': InitialSubGroup.fromString(readings[i]),
       'createdAt': FieldValue.serverTimestamp(),
       'updatedAt': FieldValue.serverTimestamp(),
     };

--- a/test/util/constant/initial_main_group_test.dart
+++ b/test/util/constant/initial_main_group_test.dart
@@ -28,7 +28,7 @@ void main() {
 
       for (var i = 0; i < hiraganaList.length; i++) {
         // * Act
-        final actual = InitialSubGroup.labelFromString(hiraganaList[i]);
+        final actual = InitialSubGroup.fromString(hiraganaList[i]);
 
         // * Assert
         final expected = expectedList[i];
@@ -61,7 +61,7 @@ void main() {
 
       for (var i = 0; i < katakanaList.length; i++) {
         // * Act
-        final actual = InitialSubGroup.labelFromString(katakanaList[i]);
+        final actual = InitialSubGroup.fromString(katakanaList[i]);
 
         // * Assert
         final expected = expectedList[i];
@@ -82,7 +82,7 @@ void main() {
 
       for (var i = 0; i < alphabetList.length; i++) {
         // * Act
-        final actual = InitialSubGroup.labelFromString(alphabetList[i]);
+        final actual = InitialSubGroup.fromString(alphabetList[i]);
 
         // * Assert
         final expected = expectedList[i];
@@ -97,7 +97,7 @@ void main() {
 
       for (var i = 0; i < numberList.length; i++) {
         // * Act
-        final actual = InitialSubGroup.labelFromString(numberList[i]);
+        final actual = InitialSubGroup.fromString(numberList[i]);
 
         // * Assert
         expect(actual, InitialSubGroup.number.label);
@@ -111,7 +111,7 @@ void main() {
 
       for (var i = 0; i < symbolList.length; i++) {
         // * Act
-        final actual = InitialSubGroup.labelFromString(symbolList[i]);
+        final actual = InitialSubGroup.fromString(symbolList[i]);
 
         // * Assert
         expect(actual, InitialSubGroup.basicSymbol.label);
@@ -125,7 +125,7 @@ void main() {
 
       for (var i = 0; i < otherList.length; i++) {
         // * Act
-        final actual = InitialSubGroup.labelFromString(otherList[i]);
+        final actual = InitialSubGroup.fromString(otherList[i]);
 
         // * Assert
         expect(actual, InitialSubGroup.other.label);
@@ -134,7 +134,7 @@ void main() {
 
     test('2文字', () {
       // * Arrange & Act
-      final actual = InitialSubGroup.labelFromString('とり');
+      final actual = InitialSubGroup.fromString('とり');
 
       // * Assert
       expect(actual, InitialSubGroup.to.label);
@@ -142,7 +142,7 @@ void main() {
 
     test('空文字', () {
       // * Arrange & Act
-      final actual = InitialSubGroup.labelFromString('');
+      final actual = InitialSubGroup.fromString('');
 
       // * Assert
       expect(actual, InitialSubGroup.other.label);

--- a/test/util/constant/initial_main_group_test.dart
+++ b/test/util/constant/initial_main_group_test.dart
@@ -28,7 +28,7 @@ void main() {
 
       for (var i = 0; i < hiraganaList.length; i++) {
         // * Act
-        final actual = InitialSubGroup.fromString(hiraganaList[i]);
+        final actual = InitialSubGroup.fromString(hiraganaList[i]).label;
 
         // * Assert
         final expected = expectedList[i];
@@ -61,7 +61,7 @@ void main() {
 
       for (var i = 0; i < katakanaList.length; i++) {
         // * Act
-        final actual = InitialSubGroup.fromString(katakanaList[i]);
+        final actual = InitialSubGroup.fromString(katakanaList[i]).label;
 
         // * Assert
         final expected = expectedList[i];
@@ -82,7 +82,7 @@ void main() {
 
       for (var i = 0; i < alphabetList.length; i++) {
         // * Act
-        final actual = InitialSubGroup.fromString(alphabetList[i]);
+        final actual = InitialSubGroup.fromString(alphabetList[i]).label;
 
         // * Assert
         final expected = expectedList[i];
@@ -97,7 +97,7 @@ void main() {
 
       for (var i = 0; i < numberList.length; i++) {
         // * Act
-        final actual = InitialSubGroup.fromString(numberList[i]);
+        final actual = InitialSubGroup.fromString(numberList[i]).label;
 
         // * Assert
         expect(actual, InitialSubGroup.number.label);
@@ -111,7 +111,7 @@ void main() {
 
       for (var i = 0; i < symbolList.length; i++) {
         // * Act
-        final actual = InitialSubGroup.fromString(symbolList[i]);
+        final actual = InitialSubGroup.fromString(symbolList[i]).label;
 
         // * Assert
         expect(actual, InitialSubGroup.basicSymbol.label);
@@ -125,7 +125,7 @@ void main() {
 
       for (var i = 0; i < otherList.length; i++) {
         // * Act
-        final actual = InitialSubGroup.fromString(otherList[i]);
+        final actual = InitialSubGroup.fromString(otherList[i]).label;
 
         // * Assert
         expect(actual, InitialSubGroup.other.label);
@@ -134,7 +134,7 @@ void main() {
 
     test('2文字', () {
       // * Arrange & Act
-      final actual = InitialSubGroup.fromString('とり');
+      final actual = InitialSubGroup.fromString('とり').label;
 
       // * Assert
       expect(actual, InitialSubGroup.to.label);
@@ -142,7 +142,7 @@ void main() {
 
     test('空文字', () {
       // * Arrange & Act
-      final actual = InitialSubGroup.fromString('');
+      final actual = InitialSubGroup.fromString('').label;
 
       // * Assert
       expect(actual, InitialSubGroup.other.label);


### PR DESCRIPTION
# 対象Issue

- #107 

# やった事

- 定義投稿 / 編集時に特定のProviderをinvalidateするよう修正

# やらなかった事

# 動作確認

- iPhone11 (実機) で実施

# その他



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the `DefinitionForWrite` class with a renamed method for improved clarity.
  - Modified the `WriteDefinitionRepository` to use a new method for deriving `initialSubGroupLabel`.

- **Documentation**
  - Updated comments to reflect navigation behavior after posting a definition.

- **Style**
  - Removed the `leadingWidth` property from the `AppBar` in the `IndividualDictionaryPage` for a cleaner UI.

- **Tests**
  - Adjusted tests to align with the updated method for obtaining labels from `InitialSubGroup` instances.

- **Chores**
  - Standardized the use of `fromString` method across various classes and tests for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->