### PR TITLE
表示するデータ画からの際のUIを作成

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -886,6 +886,9 @@ PODS:
   - PromisesSwift (2.3.1):
     - PromisesObjC (= 2.3.1)
   - RecaptchaInterop (100.0.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - sqflite (0.0.3):
     - Flutter
     - FMDB (>= 2.7.5)
@@ -908,6 +911,7 @@ DEPENDENCIES:
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
@@ -970,6 +974,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sqflite:
     :path: ".symlinks/plugins/sqflite/ios"
   url_launcher_ios:
@@ -1016,6 +1022,7 @@ SPEC CHECKSUMS:
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
   PromisesSwift: 28dca69a9c40779916ac2d6985a0192a5cb4a265
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
+  shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
   sqflite: 31f7eba61e3074736dff8807a9b41581e4f7f15a
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863

--- a/lib/core/common_widget/infinity_scroll_widget.dart
+++ b/lib/core/common_widget/infinity_scroll_widget.dart
@@ -15,6 +15,7 @@ class InfinityScrollWidget extends ConsumerWidget {
     required this.tileBuilder,
     required this.shimmerTile,
     required this.shimmerTileNumber,
+    required this.emptyWidget,
   });
 
   /// 扱うstate ([ListState]型)を保持するProvider
@@ -29,6 +30,9 @@ class InfinityScrollWidget extends ConsumerWidget {
 
   /// [shimmerTile]を表示させる数
   final int shimmerTileNumber;
+
+  /// 扱うstate ([ListState]型) の中身が空の場合に表示させるWidget
+  final Widget? emptyWidget;
 
   final scrollController = ScrollController();
   // エラーが発生してリビルドした際、スクロール位置を保持するためのキー
@@ -69,6 +73,7 @@ class InfinityScrollWidget extends ConsumerWidget {
                     ],
                   )
                 : const SizedBox(),
+            emptyWidget: emptyWidget,
           ),
         );
       },
@@ -94,6 +99,7 @@ class InfinityScrollWidget extends ConsumerWidget {
               fetchMore: fetchMore,
               asyncListState: asyncListState,
             ),
+            emptyWidget: emptyWidget,
           );
         }
 
@@ -135,6 +141,7 @@ class _StateScrollBar extends StatelessWidget {
     required this.asyncListState,
     required this.tileBuilder,
     required this.bottomWidget,
+    required this.emptyWidget,
   });
 
   final GlobalKey globalKey;
@@ -143,6 +150,7 @@ class _StateScrollBar extends StatelessWidget {
   final AsyncValue<ListState?> asyncListState;
   final Widget Function(dynamic item) tileBuilder;
   final Widget bottomWidget;
+  final Widget? emptyWidget;
 
   @override
   Widget build(BuildContext context) {
@@ -157,15 +165,17 @@ class _StateScrollBar extends StatelessWidget {
             onRefresh: onRefresh,
           ),
           SliverToBoxAdapter(
-            child: ListView.builder(
-              controller: scrollController,
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              itemCount: asyncListState.value!.list.length,
-              itemBuilder: (context, index) {
-                return tileBuilder(asyncListState.value!.list[index]);
-              },
-            ),
+            child: asyncListState.value!.list.isEmpty
+                ? emptyWidget ?? const SizedBox.shrink()
+                : ListView.builder(
+                    controller: scrollController,
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    itemCount: asyncListState.value!.list.length,
+                    itemBuilder: (context, index) {
+                      return tileBuilder(asyncListState.value!.list[index]);
+                    },
+                  ),
           ),
           SliverPadding(
             padding: const EdgeInsets.only(top: 8, bottom: 40),

--- a/lib/core/common_widget/shimmer_widget.dart
+++ b/lib/core/common_widget/shimmer_widget.dart
@@ -18,6 +18,7 @@ class ShimmerWidget extends StatelessWidget {
     required this.height,
     this.shapeBorder = const CircleBorder(),
   });
+
   final double width;
   final double height;
   final ShapeBorder shapeBorder;

--- a/lib/core/common_widget/simple_widget_for_empty.dart
+++ b/lib/core/common_widget/simple_widget_for_empty.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+/// emptyステートとして使用する [message] を表示させるだけのシンプルなWidget
+class SimpleWidgetForEmpty extends StatelessWidget {
+  const SimpleWidgetForEmpty({
+    super.key,
+    required this.message,
+  });
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const SizedBox(height: 40),
+        Center(
+          child: Text(
+            message,
+            style: Theme.of(context).textTheme.titleMedium,
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/core/router/app_router.gr.dart
+++ b/lib/core/router/app_router.gr.dart
@@ -219,6 +219,7 @@ abstract class _$AppRouter extends RootStackRouter {
         child: WordListPage(
           key: args.key,
           selectedInitialSubGroup: args.selectedInitialSubGroup,
+          
         ),
       );
     },

--- a/lib/feature/definition/presentation/component/definition_list.dart
+++ b/lib/feature/definition/presentation/component/definition_list.dart
@@ -13,6 +13,7 @@ class DefinitionList extends ConsumerWidget {
   const DefinitionList({
     super.key,
     required this.definitionFeedType,
+    required this.emptyWidget,
     this.wordId,
     this.targetUserId,
     this.initialSubGroup,
@@ -28,6 +29,9 @@ class DefinitionList extends ConsumerWidget {
   ///
   /// デフォルト値は恐らく画面を埋め尽くされるであろう数として8を設定
   final int shimmerTileNumber;
+
+  /// 扱うstateの中身が空の場合に表示させるWidget
+  final Widget? emptyWidget;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -46,6 +50,7 @@ class DefinitionList extends ConsumerWidget {
       },
       shimmerTile: const DefinitionTileShimmer(),
       shimmerTileNumber: shimmerTileNumber,
+      emptyWidget: emptyWidget,
     );
   }
 }

--- a/lib/feature/definition/presentation/page/definition_detail/definition_detail_page.dart
+++ b/lib/feature/definition/presentation/page/definition_detail/definition_detail_page.dart
@@ -188,6 +188,11 @@ class DefinitionDetailPage extends ConsumerWidget {
                         LikeWidget(definition: definition, showCount: false),
                         InkWell(
                           onTap: () async {
+                            if (definition.likesCount == 0) {
+                              // いいねが0件の場合は何もしない
+                              return;
+                            }
+
                             await context.pushRoute(
                               LikeUserRoute(definitionId: definition.id),
                             );

--- a/lib/feature/definition/presentation/page/home/home_page.dart
+++ b/lib/feature/definition/presentation/page/home/home_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import '../../../../../core/common_widget/button/post_definition_fab.dart';
 import '../../../../../core/common_widget/button/to_setting_button.dart';
+import '../../../../../core/common_widget/simple_widget_for_empty.dart';
 import '../../../../../core/common_widget/stickey_tab_bar_deligate.dart';
 import '../../../../../util/extension/scroll_controller_extension.dart';
 import '../../../util/definition_feed_type.dart';
@@ -59,9 +60,15 @@ class HomePage extends StatelessWidget {
               children: <Widget>[
                 DefinitionList(
                   definitionFeedType: DefinitionFeedType.homeRecommend,
+                  emptyWidget: SimpleWidgetForEmpty(
+                    message: 'おすすめの投稿がありません...',
+                  ),
                 ),
                 DefinitionList(
                   definitionFeedType: DefinitionFeedType.homeFollowing,
+                  emptyWidget: SimpleWidgetForEmpty(
+                    message: 'フォローしたユーザーの投稿が表示されます🏄‍♂',
+                  ),
                 ),
               ],
             ),

--- a/lib/feature/user_profile/presentation/component/profile_list.dart
+++ b/lib/feature/user_profile/presentation/component/profile_list.dart
@@ -16,11 +16,13 @@ class ProfileList extends ConsumerWidget {
     required this.userListType,
     required this.targetUserId,
     required this.targetDefinitionId,
+    required this.emptyWidget,
   });
 
   final UserListType userListType;
   final String? targetUserId;
   final String? targetDefinitionId;
+  final Widget? emptyWidget;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -44,6 +46,7 @@ class ProfileList extends ConsumerWidget {
       },
       shimmerTile: const ProfileTileShimmer(),
       shimmerTileNumber: 4,
+      emptyWidget: emptyWidget,
     );
   }
 }

--- a/lib/feature/user_profile/presentation/page/following_and_follower_list/following_and_follower_list_page.dart
+++ b/lib/feature/user_profile/presentation/page/following_and_follower_list/following_and_follower_list_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../../core/common_widget/button/to_search_user_button.dart';
+import '../../../../../core/common_widget/simple_widget_for_empty.dart';
 import '../../../../../core/common_widget/stickey_tab_bar_deligate.dart';
 import '../../../../../util/extension/scroll_controller_extension.dart';
 import '../../../../auth/application/auth_state.dart';
@@ -77,11 +78,17 @@ class FollowingAndFollowerListPage extends ConsumerWidget {
                   userListType: UserListType.following,
                   targetUserId: targetUserId,
                   targetDefinitionId: null,
+                  emptyWidget: const SimpleWidgetForEmpty(
+                    message: 'フォロー中のユーザーがいません',
+                  ),
                 ),
                 ProfileList(
                   userListType: UserListType.follower,
                   targetUserId: targetUserId,
                   targetDefinitionId: null,
+                  emptyWidget: const SimpleWidgetForEmpty(
+                    message: 'フォロワーがいません',
+                  ),
                 ),
               ],
             ),

--- a/lib/feature/user_profile/presentation/page/like_user_page.dart/like_user_page.dart
+++ b/lib/feature/user_profile/presentation/page/like_user_page.dart/like_user_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../../core/common_widget/simple_widget_for_empty.dart';
 import '../../../../../util/extension/scroll_controller_extension.dart';
 import '../../../util/profile_feed_type.dart';
 import '../../component/profile_list.dart';
@@ -30,6 +31,10 @@ class LikeUserPage extends ConsumerWidget {
         userListType: UserListType.liked,
         targetUserId: null,
         targetDefinitionId: definitionId,
+        // いいねが0件の場合、[LikeUserPage] には遷移しない想定だが念のため設定しておく
+        emptyWidget: const SimpleWidgetForEmpty(
+          message: 'まだいいね！されていません',
+        ),
       ),
     );
   }

--- a/lib/feature/user_profile/presentation/page/profile/profile_page.dart
+++ b/lib/feature/user_profile/presentation/page/profile/profile_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../../core/common_widget/button/other_user_action_icon_button.dart';
 import '../../../../../core/common_widget/button/post_definition_fab.dart';
 import '../../../../../core/common_widget/button/to_search_user_button.dart';
+import '../../../../../core/common_widget/simple_widget_for_empty.dart';
 import '../../../../../core/common_widget/stickey_tab_bar_deligate.dart';
 import '../../../../../util/extension/scroll_controller_extension.dart';
 import '../../../../../util/logger.dart';
@@ -28,14 +29,14 @@ class ProfilePage extends ConsumerWidget {
     final currentUserId = ref.watch(userIdProvider)!;
     final asyncTargetUserProfile = ref.watch(userProfileProvider(targetUserId));
 
+    final isMyProfile = currentUserId == targetUserId;
+
     return DefaultTabController(
       length: 2,
       child: SafeArea(
         child: Scaffold(
           body: NestedScrollView(
             headerSliverBuilder: (BuildContext context, bool _) {
-              final isMyProfile = currentUserId == targetUserId;
-
               return <Widget>[
                 SliverAppBar(
                   forceElevated: true,
@@ -94,10 +95,16 @@ class ProfilePage extends ConsumerWidget {
                   definitionFeedType:
                       DefinitionFeedType.profileOrderByCreatedAt,
                   targetUserId: targetUserId,
+                  emptyWidget: SimpleWidgetForEmpty(
+                    message: isMyProfile ? '🙃んせまりあは稿投だま' : '投稿がありません。',
+                  ),
                 ),
                 DefinitionList(
                   definitionFeedType: DefinitionFeedType.profileLiked,
                   targetUserId: targetUserId,
+                  emptyWidget: SimpleWidgetForEmpty(
+                    message: isMyProfile ? 'いいねした投稿が表示されます💖' : 'いいねした投稿がありません',
+                  ),
                 ),
               ],
             ),

--- a/lib/feature/word/presentation/page/individual_dictionary_definition_list/individual_dictionary_definition_list.dart
+++ b/lib/feature/word/presentation/page/individual_dictionary_definition_list/individual_dictionary_definition_list.dart
@@ -1,10 +1,14 @@
+import 'dart:math';
+
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../../core/common_widget/button/post_definition_fab.dart';
+import '../../../../../core/common_widget/simple_widget_for_empty.dart';
 import '../../../../../util/constant/initial_main_group.dart';
 import '../../../../../util/extension/scroll_controller_extension.dart';
+import '../../../../auth/application/auth_state.dart';
 import '../../../../definition/presentation/component/definition_list.dart';
 import '../../../../definition/util/definition_feed_type.dart';
 import '../../component/dictionary_author_widget.dart';
@@ -22,6 +26,32 @@ class IndividualDictionaryDefinitionListPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final isSelf = ref.watch(userIdProvider) == targetUserId;
+    String generateEmptyMessage(String initialLabel) {
+      if (!isSelf) {
+        // * 自分以外の辞書の場合
+        return '「$initialLabel」の投稿はありません';
+      }
+
+      // * 自分の辞書の場合
+      final messageList = [
+        '「$initialLabel」はまだ投稿されていません\n投稿してくれると嬉しいです😭',
+        '「$initialLabel」はまだ投稿されていません\nところで、このアプリを見つけていただきありがとうございます😊',
+        '「$initialLabel」は未開拓です..!!',
+        '「$initialLabel」は伸びしろたっぷりです😆',
+        '「$initialLabel」はまだ投稿されていません😭',
+        '「$initialLabel」デビューしませんか🥺',
+        'やあ✋私は「$initialLabel」である👴。\nここに来た記念に私を投稿してくれ',
+        'やっほー！私は「$initialLabel」だよ。投稿してくれるよね？🥺',
+        '「$initialLabel」を開くとはお目が高い！',
+        '無理にとは言わんけぇ、\n「$initialLabel」を投稿してはくれまいか？👴',
+        '🙃んせまりあは稿投だま',
+      ];
+
+      // ランダムでメッセージを返す
+      return messageList[Random().nextInt(messageList.length)];
+    }
+
     return Scaffold(
       body: NestedScrollView(
         headerSliverBuilder: (BuildContext context, bool _) {
@@ -49,6 +79,9 @@ class IndividualDictionaryDefinitionListPage extends ConsumerWidget {
                 targetUserId: targetUserId,
                 initialSubGroup: initialSubGroup,
                 shimmerTileNumber: 1,
+                emptyWidget: SimpleWidgetForEmpty(
+                  message: generateEmptyMessage(initialSubGroup.label),
+                ),
               ),
             ),
           ],

--- a/lib/feature/word/presentation/page/search_word_result/search_word_result_page.dart
+++ b/lib/feature/word/presentation/page/search_word_result/search_word_result_page.dart
@@ -1,9 +1,12 @@
+import 'dart:math';
+
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../../core/common_widget/button/post_definition_fab.dart';
 import '../../../../../core/common_widget/infinity_scroll_widget.dart';
+import '../../../../../core/common_widget/simple_widget_for_empty.dart';
 import '../../../../../util/extension/scroll_controller_extension.dart';
 import '../../../application/word_list_state_by_search_word.dart';
 import '../../../domain/word.dart';
@@ -25,37 +28,57 @@ class SearchWordResultPage extends ConsumerWidget {
     final wordListProvider =
         wordListStateBySearchWordNotifierProvider(searchWord);
 
+    String generateEmptyMessage(String label) {
+      // * 自分の辞書の場合
+      final messageList = [
+        '検索した語句は見つかりませんでした。',
+        '検索した語句は見つかりませんでした。。\nどうでしょう、あなたが投稿しませんか？😎',
+      ];
+
+      // ランダムでメッセージを返す
+      return messageList[Random().nextInt(messageList.length)];
+    }
+
     return Scaffold(
-      appBar: AppBar(
-        title: InkWell(
-          child: const Text('検索結果'),
-          onTap: () => PrimaryScrollController.of(context).scrollToTop(),
-        ),
-        leading: const BackButton(),
-        flexibleSpace: InkWell(
-          onTap: () => PrimaryScrollController.of(context).scrollToTop(),
-        ),
-      ),
-      body: Column(
-        children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(
-              vertical: 24,
-              horizontal: 36,
+      body: NestedScrollView(
+        headerSliverBuilder: (BuildContext context, bool _) {
+          return <Widget>[
+            SliverAppBar(
+              forceElevated: true,
+              pinned: true,
+              title: InkWell(
+                child: const Text('検索結果'),
+                onTap: () => PrimaryScrollController.of(context).scrollToTop(),
+              ),
+              leading: const BackButton(),
+              flexibleSpace: InkWell(
+                onTap: () => PrimaryScrollController.of(context).scrollToTop(),
+              ),
             ),
-            child: SearchWordTextField(defaultText: searchWord),
-          ),
-          const SizedBox(height: 8),
-          Expanded(
-            child: InfinityScrollWidget(
-              listStateNotifierProvider: wordListProvider,
-              fetchMore: ref.read(wordListProvider.notifier).fetchMore,
-              tileBuilder: (item) => WordTile(word: item as Word),
-              shimmerTile: const WordTileShimmer(),
-              shimmerTileNumber: 2,
+          ];
+        },
+        body: Column(
+          children: [
+            const SizedBox(height: 24),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 36),
+              child: SearchWordTextField(defaultText: searchWord),
             ),
-          ),
-        ],
+            const SizedBox(height: 16),
+            Expanded(
+              child: InfinityScrollWidget(
+                listStateNotifierProvider: wordListProvider,
+                fetchMore: ref.read(wordListProvider.notifier).fetchMore,
+                tileBuilder: (item) => WordTile(word: item as Word),
+                shimmerTile: const WordTileShimmer(),
+                shimmerTileNumber: 2,
+                emptyWidget: SimpleWidgetForEmpty(
+                  message: generateEmptyMessage(searchWord),
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
       floatingActionButton: const PostDefinitionFAB(),
     );

--- a/lib/feature/word/presentation/page/search_word_result/search_word_result_page.dart
+++ b/lib/feature/word/presentation/page/search_word_result/search_word_result_page.dart
@@ -29,7 +29,6 @@ class SearchWordResultPage extends ConsumerWidget {
         wordListStateBySearchWordNotifierProvider(searchWord);
 
     String generateEmptyMessage(String label) {
-      // * 自分の辞書の場合
       final messageList = [
         '検索した語句は見つかりませんでした。',
         '検索した語句は見つかりませんでした。。\nどうでしょう、あなたが投稿しませんか？😎',

--- a/lib/feature/word/presentation/page/word_list/word_list_page.dart
+++ b/lib/feature/word/presentation/page/word_list/word_list_page.dart
@@ -1,9 +1,12 @@
+import 'dart:math';
+
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../../core/common_widget/button/post_definition_fab.dart';
 import '../../../../../core/common_widget/infinity_scroll_widget.dart';
+import '../../../../../core/common_widget/simple_widget_for_empty.dart';
 import '../../../../../util/constant/initial_main_group.dart';
 import '../../../../../util/extension/scroll_controller_extension.dart';
 import '../../../application/word_list_state_by_initial.dart';
@@ -25,6 +28,25 @@ class WordListPage extends ConsumerWidget {
     final wordListProvider =
         wordListStateByInitialNotifierProvider(selectedInitialSubGroup.label);
 
+    String generateEmptyMessage(String initialLabel) {
+      final messageList = [
+        '「$initialLabel」はまだ誰にも投稿されていません。\n第一人者になるチャンスです..!!',
+        '「$initialLabel」はまだ投稿されていません\n投稿してくれると嬉しいです😭',
+        '「$initialLabel」は未開拓です..!!',
+        '「$initialLabel」は伸びしろたっぷりです😆',
+        '「$initialLabel」はまだ投稿されていません😭',
+        '「$initialLabel」はまだ誰も投稿していません...!!',
+        'やあ✋私は「$initialLabel」である👴。\nここに来た記念に私を投稿してくれ',
+        'やっほー！私は「$initialLabel」だよ。投稿してくれるよね？🥺',
+        '「$initialLabel」を開くとはお目が高い！',
+        '無理にとは言わんけぇ、\n「$initialLabel」を投稿してはくれまいか？👴',
+        '🙃んせまりあは稿投だま',
+      ];
+
+      // ランダムでメッセージを返す
+      return messageList[Random().nextInt(messageList.length)];
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: InkWell(
@@ -42,6 +64,9 @@ class WordListPage extends ConsumerWidget {
         tileBuilder: (item) => WordTile(word: item as Word),
         shimmerTile: const WordTileShimmer(),
         shimmerTileNumber: 10,
+        emptyWidget: SimpleWidgetForEmpty(
+          message: generateEmptyMessage(selectedInitialSubGroup.label),
+        ),
       ),
       floatingActionButton: const PostDefinitionFAB(),
     );

--- a/lib/feature/word/presentation/page/word_top/word_top_page.dart
+++ b/lib/feature/word/presentation/page/word_top/word_top_page.dart
@@ -75,6 +75,7 @@ class WordTopPage extends ConsumerWidget {
                 ),
               ];
             },
+            // WordTopは定義が投稿されていないと開けないので、emptyWidgetはnull
             body: TabBarView(
               children: [
                 DefinitionList(
@@ -82,12 +83,14 @@ class WordTopPage extends ConsumerWidget {
                       DefinitionFeedType.wordTopOrderByCreatedAt,
                   wordId: wordId,
                   shimmerTileNumber: 2,
+                  emptyWidget: null,
                 ),
                 DefinitionList(
                   definitionFeedType:
                       DefinitionFeedType.wordTopOrderByLikesCount,
                   wordId: wordId,
                   shimmerTileNumber: 2,
+                  emptyWidget: null,
                 ),
               ],
             ),


### PR DESCRIPTION
# 対象Issue

- #109 
- #110 

# やった事

- 表示するデータ画からの際のUIを作成
- 語句検索画面でスワイプリフレッシュできない問題を解決

# やらなかった事

# 動作確認

- iPhone11 (実機) で実施

# その他



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `SimpleWidgetForEmpty` to display custom messages for empty states across various lists and pages.
  - Added empty state handling with custom messages for `InfinityScrollWidget`, `DefinitionList`, `ProfileList`, and other list components.
  - Implemented conditional navigation logic in `DefinitionDetailPage` to prevent routing to `LikeUserRoute` when likes count is zero.

- **Enhancements**
  - Enhanced user experience by providing informative empty state messages in user profiles, word lists, and search results.
  - Improved visual feedback for empty lists with the integration of `SimpleWidgetForEmpty`.

- **Bug Fixes**
  - Fixed an issue where empty lists did not provide user feedback by implementing `emptyWidget` across the application.

- **Refactor**
  - Refactored list components to accept an `emptyWidget` parameter for customizable empty states.

- **Style**
  - Minor style adjustments with the addition of `emptyWidget` styling across the app.

- **Chores**
  - Cleaned up code with the addition of whitespace in `shimmer_widget.dart` for better readability.
  - Added trailing commas in router definitions for consistent code style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->