### PR TITLE
利用規約 / プライバシーポリシー / 使い方 ページへの遷移を実装

### DIFF
--- a/lib/feature/force_event/presentation/overlay_in_maintenance_dialog.dart
+++ b/lib/feature/force_event/presentation/overlay_in_maintenance_dialog.dart
@@ -50,7 +50,7 @@ class OverlayInMaintenanceDialog extends ConsumerWidget {
                   const SizedBox(height: 16),
                   PrimaryFilledButton(
                     onPressed: () {
-                      ref.read(launchURLProvider(latestInformationPage));
+                      ref.read(launchURLProvider(latestInformationPageUrl));
                     },
                     text: '最新情報を確認する',
                   ),

--- a/lib/feature/setting/presentation/setting_page.dart
+++ b/lib/feature/setting/presentation/setting_page.dart
@@ -68,7 +68,7 @@ class SettingPage extends ConsumerWidget {
             SettingTileButton(
               trailingIcon: const Icon(CupertinoIcons.question_square),
               label: '使い方',
-              onTap: () {}, // TODO(me): 使い方画面へ遷移（WebToでNotion）
+              onTap: () => ref.read(launchURLProvider(howToPageUrl)),
             ),
             const SizedBox(height: 24),
             SettingTileButton(
@@ -106,7 +106,7 @@ class SettingPage extends ConsumerWidget {
             SettingTileButton(
               trailingIcon: const Icon(CupertinoIcons.exclamationmark_shield),
               label: 'プライバシーポリシー',
-              onTap: () => ref.read(launchURLProvider(privacyPolicyUrl)),
+              onTap: () => ref.read(launchURLProvider(privacyPolicyPageUrl)),
             ),
             const SizedBox(height: 24),
             SettingTileButton(

--- a/lib/feature/setting/presentation/setting_page.dart
+++ b/lib/feature/setting/presentation/setting_page.dart
@@ -100,13 +100,13 @@ class SettingPage extends ConsumerWidget {
             SettingTileButton(
               trailingIcon: const Icon(CupertinoIcons.doc_text),
               label: '利用規約',
-              onTap: () {}, // TODO(me): 利用規約画面へ遷移（WebToでNotion）
+              onTap: () => ref.read(launchURLProvider(termPageUrl)),
             ),
             const SizedBox(height: 24),
             SettingTileButton(
               trailingIcon: const Icon(CupertinoIcons.exclamationmark_shield),
               label: 'プライバシーポリシー',
-              onTap: () {}, // TODO(me): プライバシーポリシー画面へ遷移（WebToでNotion）
+              onTap: () => ref.read(launchURLProvider(privacyPolicyUrl)),
             ),
             const SizedBox(height: 24),
             SettingTileButton(

--- a/lib/util/constant/url.dart
+++ b/lib/util/constant/url.dart
@@ -1,5 +1,11 @@
-const latestInformationPage =
+const latestInformationPageUrl =
     'https://almondine-ixora-d9e.notion.site/8e8ca7ad482a473099743dddb3b930ab?pvs=4';
+
+const termPageUrl =
+    'https://almondine-ixora-d9e.notion.site/cf91474015864ce381297e89be7a6e1e?pvs=4';
+
+const privacyPolicyUrl =
+    'https://almondine-ixora-d9e.notion.site/d6aee44eb66a4d4b88fe0a89c6e3da00?pvs=4';
 
 String userReportFormUrl({
   required String targetUserPublicId,

--- a/lib/util/constant/url.dart
+++ b/lib/util/constant/url.dart
@@ -4,8 +4,11 @@ const latestInformationPageUrl =
 const termPageUrl =
     'https://almondine-ixora-d9e.notion.site/cf91474015864ce381297e89be7a6e1e?pvs=4';
 
-const privacyPolicyUrl =
+const privacyPolicyPageUrl =
     'https://almondine-ixora-d9e.notion.site/d6aee44eb66a4d4b88fe0a89c6e3da00?pvs=4';
+
+const howToPageUrl =
+    'https://almondine-ixora-d9e.notion.site/c1c523c7a9e949208dc814c50b2c4477?pvs=4';
 
 String userReportFormUrl({
   required String targetUserPublicId,


### PR DESCRIPTION
# 対象Issue

- #31 

# やった事

- 利用規約 / プライバシーポリシー / 使い方 ページへの遷移を実装
- 利用規約, プライバシーポリシーをKIYACで作成

# やらなかった事

- 使い方ページの内容作成

# 動作確認

- iPhone11 (実機) で実施

# その他



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the maintenance overlay to direct users to the latest information page via a new URL.
  - Enhanced the settings page with direct links to the "How-To," "Terms of Service," and "Privacy Policy" pages.

- **Refactor**
  - Renamed a URL variable for clarity and consistency.
  - Added new URL constants for improved navigation and user reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->